### PR TITLE
end-to-end integration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -197,9 +197,16 @@
   version = "v1.3.0"
 
 [[projects]]
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
+  version = "v0.1.1"
+
+[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
+    "mock",
     "require",
     "suite"
   ]
@@ -434,6 +441,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d473c1db7f86def1b63e76f1a53cf5f59b7d0a9ec017358bf83a79a89ceaa66f"
+  inputs-digest = "d9382fc279e26859e1840bd000909ec761ffc5b25324518f6a5283451e303beb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/lookout/analyze.go
+++ b/cmd/lookout/analyze.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/service/bblfsh"
+	"github.com/src-d/lookout/service/git"
+
+	"google.golang.org/grpc"
+	gogit "gopkg.in/src-d/go-git.v4"
+	gogitsrv "gopkg.in/src-d/go-git.v4/plumbing/transport/server"
+)
+
+func init() {
+	if _, err := parser.AddCommand("analyze", "analyzes HEAD", "",
+		&AnalyzeCommand{}); err != nil {
+		panic(err)
+	}
+}
+
+type AnalyzeCommand struct {
+	Analyzer   string `long:"analyzer" default:"ipv4://localhost:10302" env:"LOOKOUT_ANALYZER" description:"gRPC URL of the analyzer to use"`
+	DataServer string `long:"data-server" default:"ipv4://localhost:10301" env:"LOOKOUT_DATA_SERVER" description:"gRPC URL to bind the data server to"`
+	Bblfshd    string `long:"bblfshd" default:"ipv4://localhost:9432" env:"LOOKOUT_BBLFSHD" description:"gRPC URL of the Bblfshd server"`
+	GitDir     string `long:"git-dir" default:"." env:"GIT_DIR" description:"path to the .git directory to analyze"`
+}
+
+func (c *AnalyzeCommand) Execute(args []string) error {
+	r, err := gogit.PlainOpenWithOptions(c.GitDir, &gogit.PlainOpenOptions{
+		DetectDotGit: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	headRef, err := r.Head()
+	if err != nil {
+		return err
+	}
+
+	headCommit, err := r.CommitObject(headRef.Hash())
+	if err != nil {
+		return err
+	}
+
+	headHash := headCommit.Hash.String()
+
+	var parentHash string
+	if len(headCommit.ParentHashes) > 0 {
+		parentCommit, err := headCommit.Parent(0)
+		if err != nil {
+			return err
+		}
+
+		parentHash = parentCommit.Hash.String()
+	}
+
+	c.Bblfshd, err = lookout.ToGoGrpcAddress(c.Bblfshd)
+	if err != nil {
+		return err
+	}
+
+	bblfshConn, err := grpc.Dial(c.Bblfshd, grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+
+	l := gogitsrv.MapLoader{
+		"file:///repo": r.Storer,
+	}
+	srv := &lookout.DataServerHandler{
+		ChangeGetter: bblfsh.NewService(
+			git.NewService(l),
+			bblfshConn,
+		),
+	}
+	grpcSrv := grpc.NewServer()
+	lookout.RegisterDataServer(grpcSrv, srv)
+	lis, err := lookout.Listen(c.DataServer)
+	if err != nil {
+		return err
+	}
+
+	serveResult := make(chan error)
+	go func() { serveResult <- grpcSrv.Serve(lis) }()
+
+	c.Analyzer, err = lookout.ToGoGrpcAddress(c.Analyzer)
+	if err != nil {
+		return err
+	}
+
+	conn, err := grpc.Dial(c.Analyzer, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return err
+	}
+
+	client := lookout.NewAnalyzerClient(conn)
+	resp, err := client.NotifyPullRequestEvent(context.TODO(),
+		&lookout.PullRequestEvent{
+			CommitRevision: lookout.CommitRevision{
+				Base: lookout.ReferencePointer{
+					InternalRepositoryURL: "file:///repo",
+					Hash: parentHash,
+				},
+				Head: lookout.ReferencePointer{
+					InternalRepositoryURL: "file:///repo",
+					Hash: headHash,
+				},
+			}})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("BEGIN RESULT")
+	for _, comment := range resp.Comments {
+		if comment.File == "" {
+			fmt.Printf("GLOBAL: %s\n", comment.Text)
+			continue
+		}
+
+		if comment.Line == 0 {
+			fmt.Printf("%s: %s\n", comment.File, comment.Text)
+			continue
+		}
+
+		fmt.Printf("%s:%d: %s\n", comment.File, comment.Line, comment.Text)
+	}
+
+	fmt.Println("END RESULT")
+
+	grpcSrv.GracefulStop()
+	return <-serveResult
+}

--- a/cmd/lookout/analyze.go
+++ b/cmd/lookout/analyze.go
@@ -10,7 +10,6 @@ import (
 
 	"google.golang.org/grpc"
 	gogit "gopkg.in/src-d/go-git.v4"
-	gogitsrv "gopkg.in/src-d/go-git.v4/plumbing/transport/server"
 )
 
 func init() {
@@ -67,12 +66,10 @@ func (c *AnalyzeCommand) Execute(args []string) error {
 		return err
 	}
 
-	l := gogitsrv.MapLoader{
-		"file:///repo": r.Storer,
-	}
+	loader := git.NewStorerCommitLoader(r.Storer)
 	srv := &lookout.DataServerHandler{
 		ChangeGetter: bblfsh.NewService(
-			git.NewService(l),
+			git.NewService(loader),
 			bblfshConn,
 		),
 	}

--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -1,143 +1,15 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"os"
 
-	"github.com/src-d/lookout"
-	"github.com/src-d/lookout/service/bblfsh"
-	"github.com/src-d/lookout/service/git"
-
 	"github.com/jessevdk/go-flags"
-	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/grpclog/glogger"
-	gogit "gopkg.in/src-d/go-git.v4"
-	gogitsrv "gopkg.in/src-d/go-git.v4/plumbing/transport/server"
 )
 
 var parser = flags.NewParser(nil, flags.Default)
 
-type AnalyzeCommand struct {
-	Analyzer   string `long:"analyzer" default:"ipv4://localhost:10302" env:"LOOKOUT_ANALYZER" description:"gRPC URL of the analyzer to use"`
-	DataServer string `long:"data-server" default:"ipv4://localhost:10301" env:"LOOKOUT_DATA_SERVER" description:"gRPC URL to bind the data server to"`
-	Bblfshd    string `long:"bblfshd" default:"ipv4://localhost:9432" env:"LOOKOUT_BBLFSHD" description:"gRPC URL of the Bblfshd server"`
-	GitDir     string `long:"git-dir" default:"." env:"GIT_DIR" description:"path to the .git directory to analyze"`
-}
-
-func (c *AnalyzeCommand) Execute(args []string) error {
-	r, err := gogit.PlainOpenWithOptions(c.GitDir, &gogit.PlainOpenOptions{
-		DetectDotGit: true,
-	})
-	if err != nil {
-		return err
-	}
-
-	headRef, err := r.Head()
-	if err != nil {
-		return err
-	}
-
-	headCommit, err := r.CommitObject(headRef.Hash())
-	if err != nil {
-		return err
-	}
-
-	headHash := headCommit.Hash.String()
-
-	var parentHash string
-	if len(headCommit.ParentHashes) > 0 {
-		parentCommit, err := headCommit.Parent(0)
-		if err != nil {
-			return err
-		}
-
-		parentHash = parentCommit.Hash.String()
-	}
-
-	c.Bblfshd, err = lookout.ToGoGrpcAddress(c.Bblfshd)
-	if err != nil {
-		return err
-	}
-
-	bblfshConn, err := grpc.Dial(c.Bblfshd, grpc.WithInsecure())
-	if err != nil {
-		return err
-	}
-
-	l := gogitsrv.MapLoader{
-		"repo:///repo": r.Storer,
-	}
-	srv := &lookout.DataServerHandler{
-		ChangeGetter: bblfsh.NewService(
-			git.NewService(l),
-			bblfshConn,
-		),
-	}
-	grpcSrv := grpc.NewServer()
-	lookout.RegisterDataServer(grpcSrv, srv)
-	lis, err := lookout.Listen(c.DataServer)
-	if err != nil {
-		return err
-	}
-
-	serveResult := make(chan error)
-	go func() { serveResult <- grpcSrv.Serve(lis) }()
-
-	c.Analyzer, err = lookout.ToGoGrpcAddress(c.Analyzer)
-	if err != nil {
-		return err
-	}
-
-	conn, err := grpc.Dial(c.Analyzer, grpc.WithInsecure(), grpc.WithBlock())
-	if err != nil {
-		return err
-	}
-
-	client := lookout.NewAnalyzerClient(conn)
-	resp, err := client.NotifyPullRequestEvent(context.TODO(),
-		&lookout.PullRequestEvent{
-			CommitRevision: lookout.CommitRevision{
-				Base: lookout.ReferencePointer{
-					InternalRepositoryURL: "file:///repo",
-					Hash: parentHash,
-				},
-				Head: lookout.ReferencePointer{
-					InternalRepositoryURL: "file:///repo",
-					Hash: headHash,
-				},
-			}})
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("BEGIN RESULT")
-	for _, comment := range resp.Comments {
-		if comment.File == "" {
-			fmt.Printf("GLOBAL: %s\n", comment.Text)
-			continue
-		}
-
-		if comment.Line == 0 {
-			fmt.Printf("%s: %s\n", comment.File, comment.Text)
-			continue
-		}
-
-		fmt.Printf("%s:%d: %s\n", comment.File, comment.Line, comment.Text)
-	}
-
-	fmt.Println("END RESULT")
-
-	grpcSrv.GracefulStop()
-	return <-serveResult
-}
-
 func main() {
-	if _, err := parser.AddCommand("analyze", "analyzes HEAD", "",
-		&AnalyzeCommand{}); err != nil {
-		panic(err)
-	}
-
 	if _, err := parser.Parse(); err != nil {
 		if err, ok := err.(*flags.Error); ok {
 			if err.Type == flags.ErrHelp {

--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -5,7 +5,12 @@ import (
 
 	"github.com/jessevdk/go-flags"
 	_ "google.golang.org/grpc/grpclog/glogger"
+	"gopkg.in/src-d/go-log.v1"
 )
+
+func init() {
+	log.DefaultLogger = log.New(log.Fields{"app": "lookout"})
+}
 
 var parser = flags.NewParser(nil, flags.Default)
 

--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/provider/github"
+	"github.com/src-d/lookout/service/bblfsh"
+	"github.com/src-d/lookout/service/git"
+
+	"google.golang.org/grpc"
+	"gopkg.in/src-d/go-billy.v4/osfs"
+	"gopkg.in/src-d/go-log.v1"
+)
+
+func init() {
+	if _, err := parser.AddCommand("serve", "run server", "",
+		&ServeCommand{}); err != nil {
+		panic(err)
+	}
+}
+
+type ServeCommand struct {
+	Analyzer   string `long:"analyzer" default:"ipv4://localhost:10302" env:"LOOKOUT_ANALYZER" description:"gRPC URL of the analyzer to use"`
+	DataServer string `long:"data-server" default:"ipv4://localhost:10301" env:"LOOKOUT_DATA_SERVER" description:"gRPC URL to bind the data server to"`
+	Bblfshd    string `long:"bblfshd" default:"ipv4://localhost:9432" env:"LOOKOUT_BBLFSHD" description:"gRPC URL of the Bblfshd server"`
+	Library    string `long:"library" default:"/tmp/lookout" env:"LOOKOUT_LIBRARY" description:"path to the lookout library"`
+	Positional struct {
+		Repository string `positional-arg-name:"repository"`
+	} `positional-args:"yes" required:"yes"`
+
+	analyzer lookout.AnalyzerClient
+}
+
+func (c *ServeCommand) Execute(args []string) error {
+	if err := c.startServer(); err != nil {
+		return err
+	}
+
+	if err := c.initAnalyzer(); err != nil {
+		return err
+	}
+
+	watcher, err := github.NewWatcher(&lookout.WatchOptions{
+		URL: c.Positional.Repository,
+	})
+	if err != nil {
+		return err
+	}
+
+	return watcher.Watch(context.Background(), c.handleEvent)
+}
+
+func (c *ServeCommand) initAnalyzer() error {
+	var err error
+	c.Analyzer, err = lookout.ToGoGrpcAddress(c.Analyzer)
+	if err != nil {
+		return err
+	}
+
+	conn, err := grpc.Dial(c.Analyzer, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return err
+	}
+
+	c.analyzer = lookout.NewAnalyzerClient(conn)
+	return nil
+
+}
+
+func (c *ServeCommand) startServer() error {
+	var err error
+	c.Bblfshd, err = lookout.ToGoGrpcAddress(c.Bblfshd)
+	if err != nil {
+		return err
+	}
+
+	bblfshConn, err := grpc.Dial(c.Bblfshd, grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+
+	lib := git.NewLibrary(osfs.New(c.Library))
+	sync := git.NewSyncer(lib)
+	loader := git.NewLibraryCommitLoader(lib, sync)
+
+	srv := &lookout.DataServerHandler{
+		ChangeGetter: bblfsh.NewService(
+			git.NewService(loader),
+			bblfshConn,
+		),
+	}
+	grpcSrv := grpc.NewServer()
+	lookout.RegisterDataServer(grpcSrv, srv)
+	lis, err := lookout.Listen(c.DataServer)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		if err := grpcSrv.Serve(lis); err != nil {
+			log.Errorf(err, "data server failed")
+		}
+	}()
+	return nil
+}
+
+func (c *ServeCommand) handleEvent(e lookout.Event) error {
+	switch ev := e.(type) {
+	case *lookout.PullRequestEvent:
+		return c.handlePR(ev)
+	default:
+		log.Debugf("ignoring unsupported event: %s", ev)
+		return nil
+	}
+}
+
+func (c *ServeCommand) handlePR(e *lookout.PullRequestEvent) error {
+	log := log.New(log.Fields{
+		"provider":   e.Provider,
+		"repository": e.Head.InternalRepositoryURL,
+		"head":       e.Head.ReferenceName,
+	})
+	log.Infof("processing pull request")
+	resp, err := c.analyzer.NotifyPullRequestEvent(context.TODO(), e)
+	if err != nil {
+		log.Errorf(err, "analysis failed")
+		return nil
+	}
+
+	poster := &LogPoster{log}
+	return poster.Post(context.TODO(), e, resp.Comments)
+}
+
+type LogPoster struct {
+	Log log.Logger
+}
+
+func (p *LogPoster) Post(ctx context.Context, e lookout.Event,
+	comments []*lookout.Comment) error {
+	for _, c := range comments {
+		logger := p.Log.With(log.Fields{
+			"text": c.Text,
+		})
+		if c.File == "" {
+			logger.Infof("global comment")
+			continue
+		}
+
+		logger = logger.With(log.Fields{"file": c.File})
+		if c.Line == 0 {
+			logger.Infof("file comment")
+			continue
+		}
+
+		logger.With(log.Fields{"line": c.Line}).Infof("line comment")
+	}
+
+	return nil
+}

--- a/data.go
+++ b/data.go
@@ -19,7 +19,7 @@ type File = pb.File
 type ChangeGetter interface {
 	// GetChanges returns a ChangeScanner that scans all changes according
 	// to the request.
-	GetChanges(*ChangesRequest) (ChangeScanner, error)
+	GetChanges(context.Context, *ChangesRequest) (ChangeScanner, error)
 }
 
 func RegisterDataServer(s *grpc.Server, srv *DataServerHandler) {
@@ -52,7 +52,7 @@ func (s *DataServerHandler) GetChanges(req *ChangesRequest,
 
 	ctx := srv.Context()
 	cancel := ctx.Done()
-	iter, err := s.ChangeGetter.GetChanges(req)
+	iter, err := s.ChangeGetter.GetChanges(ctx, req)
 	if err != nil {
 		return err
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -225,7 +225,7 @@ type MockService struct {
 	Error           error
 }
 
-func (r *MockService) GetChanges(req *ChangesRequest) (
+func (r *MockService) GetChanges(ctx context.Context, req *ChangesRequest) (
 	ChangeScanner, error) {
 	require := require.New(r.T)
 	require.Equal(r.ExpectedRequest, req)

--- a/dummy/dummy_test.go
+++ b/dummy/dummy_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"gopkg.in/src-d/go-git-fixtures.v3"
-	gitsrv "gopkg.in/src-d/go-git.v4/plumbing/transport/server"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
@@ -42,11 +41,7 @@ func (s *DummySuite) SetupSuite() {
 
 	s.apiServer = grpc.NewServer()
 	server := &lookout.DataServerHandler{
-		ChangeGetter: git.NewService(
-			gitsrv.MapLoader{
-				"file:///fixture/basic": sto,
-			},
-		),
+		ChangeGetter: git.NewService(&git.StorerCommitLoader{sto}),
 	}
 	lookout.RegisterDataServer(s.apiServer, server)
 

--- a/poster.go
+++ b/poster.go
@@ -1,0 +1,9 @@
+package lookout
+
+import "context"
+
+// Poster can post comments about an event.
+type Poster interface {
+	// Post posts comments about an event.
+	Post(context.Context, Event, []*Comment) error
+}

--- a/provider/github/diff.go
+++ b/provider/github/diff.go
@@ -1,0 +1,169 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/google/go-github/github"
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var (
+	ErrLineOutOfDiff = errors.NewKind("line number is not in diff")
+)
+
+type diffLines struct {
+	cc     *github.CommitsComparison
+	parsed map[string][]*posRange
+}
+
+type hunk struct {
+	OldStartLine, OldLines int
+	NewStartLine, NewLines int
+}
+
+type posRange struct {
+	AbsStart, AbsEnd int
+	RelStart, RelEnd int
+}
+
+func newDiffLines(cc *github.CommitsComparison) *diffLines {
+	return &diffLines{
+		cc:     cc,
+		parsed: make(map[string][]*posRange, len(cc.Files)),
+	}
+}
+
+func (d *diffLines) ConvertLine(file string, line int) (int, error) {
+	ranges, err := d.ranges(file)
+	if err != nil {
+		return 0, err
+	}
+
+	return d.convertLine(ranges, line)
+}
+
+func (d *diffLines) convertLine(ranges []*posRange, line int) (int, error) {
+	for _, r := range ranges {
+		if line >= r.AbsStart && line < r.AbsEnd {
+			return line - r.AbsStart + r.RelStart, nil
+		}
+	}
+
+	return 0, fmt.Errorf("line position is not in diff range")
+}
+
+func (d *diffLines) ranges(file string) ([]*posRange, error) {
+	if ranges, ok := d.parsed[file]; ok {
+		return ranges, nil
+	}
+
+	hunks, err := d.hunks(file)
+	if err != nil {
+		return nil, err
+	}
+
+	ranges := convertRanges(hunks)
+	d.parsed[file] = ranges
+	return ranges, nil
+}
+
+func (d *diffLines) hunks(file string) ([]*hunk, error) {
+	var ff *github.CommitFile
+	for _, f := range d.cc.Files {
+		if file == *f.Filename {
+			ff = &f
+			break
+		}
+	}
+
+	if ff == nil {
+		return nil, fmt.Errorf("file not found: %s", file)
+	}
+
+	return parseHunks(*ff.Patch)
+}
+
+func parseHunks(s string) ([]*hunk, error) {
+	i := 0
+	var hs []*hunk
+	for i < len(s) {
+		read, h, err := parseHunk(s[i:])
+		if err != nil {
+			return nil, err
+		}
+
+		i += read
+		hs = append(hs, h)
+	}
+
+	return hs, nil
+}
+
+var hunkPattern = regexp.MustCompile(`^(@@ -(\d+),(\d+) \+(\d+)(?:,(\d+))? @@[^@]*)(?:@@.*|$)`)
+
+func parseHunk(s string) (int, *hunk, error) {
+	var (
+		err error
+		h   = &hunk{}
+	)
+	matches := hunkPattern.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		return 0, nil, fmt.Errorf("bad hunk format")
+	}
+
+	h.OldStartLine, err = strconv.Atoi(matches[2])
+	if err != nil {
+		return 0, nil, fmt.Errorf("bad hunk format")
+	}
+
+	h.OldLines, err = strconv.Atoi(matches[3])
+	if err != nil {
+		return 0, nil, fmt.Errorf("bad hunk format")
+	}
+
+	h.NewStartLine, err = strconv.Atoi(matches[4])
+	if err != nil {
+		return 0, nil, fmt.Errorf("bad hunk format")
+	}
+
+	if matches[5] == "" {
+		h.NewLines = 1
+	} else {
+		h.NewLines, err = strconv.Atoi(matches[5])
+		if err != nil {
+			return 0, nil, fmt.Errorf("bad hunk format")
+		}
+	}
+
+	return len(matches[1]), h, nil
+}
+
+func convertRanges(hunks []*hunk) []*posRange {
+	if len(hunks) == 0 {
+		return nil
+	}
+
+	ranges := make([]*posRange, len(hunks))
+	for i, hunk := range hunks {
+		if i == 0 {
+			ranges[0] = &posRange{
+				AbsStart: hunk.NewStartLine,
+				AbsEnd:   hunk.NewStartLine + hunk.NewLines,
+				RelStart: 1,
+				RelEnd:   1 + hunk.NewLines,
+			}
+			continue
+		}
+
+		ranges[i] = &posRange{
+			AbsStart: hunk.NewStartLine,
+			AbsEnd:   hunk.NewStartLine + hunk.NewLines,
+			RelStart: ranges[i-1].RelEnd + 1,
+			RelEnd:   ranges[i-1].RelEnd + 1 + hunk.NewLines,
+		}
+	}
+
+	return ranges
+}

--- a/provider/github/diff_test.go
+++ b/provider/github/diff_test.go
@@ -18,6 +18,15 @@ func TestParseHunks(t *testing.T) {
 		NewLines:     1,
 	}}, hunks)
 
+	hunks, err = parseHunks("@@ -1 +1,3 @@")
+	require.NoError(err)
+	require.Equal([]*hunk{&hunk{
+		OldStartLine: 1,
+		OldLines:     1,
+		NewStartLine: 1,
+		NewLines:     3,
+	}}, hunks)
+
 	hunks, err = parseHunks("@@ -132,7 +132,7 @@")
 	require.NoError(err)
 	require.Equal([]*hunk{&hunk{

--- a/provider/github/diff_test.go
+++ b/provider/github/diff_test.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHunks(t *testing.T) {
+	require := require.New(t)
+
+	hunks, err := parseHunks("@@ -0,0 +1 @@")
+	require.NoError(err)
+	require.Equal([]*hunk{&hunk{
+		OldStartLine: 0,
+		OldLines:     0,
+		NewStartLine: 1,
+		NewLines:     1,
+	}}, hunks)
+
+	hunks, err = parseHunks("@@ -132,7 +132,7 @@")
+	require.NoError(err)
+	require.Equal([]*hunk{&hunk{
+		OldStartLine: 132,
+		OldLines:     7,
+		NewStartLine: 132,
+		NewLines:     7,
+	}}, hunks)
+
+	hunks, err = parseHunks("@@ -132,7 +132,7 @@ module Test @@ -1000,7 +1000,7 @@ module Test")
+	require.NoError(err)
+	require.Equal([]*hunk{&hunk{
+		OldStartLine: 132,
+		OldLines:     7,
+		NewStartLine: 132,
+		NewLines:     7,
+	}, &hunk{
+		OldStartLine: 1000,
+		OldLines:     7,
+		NewStartLine: 1000,
+		NewLines:     7,
+	}}, hunks)
+
+	hunks, err = parseHunks("@@ -132,7 +132,7 @@@@ -1000,7 +1000,7 @@")
+	require.NoError(err)
+	require.Equal([]*hunk{&hunk{
+		OldStartLine: 132,
+		OldLines:     7,
+		NewStartLine: 132,
+		NewLines:     7,
+	}, &hunk{
+		OldStartLine: 1000,
+		OldLines:     7,
+		NewStartLine: 1000,
+		NewLines:     7,
+	}}, hunks)
+}
+
+func TestConvertRanges(t *testing.T) {
+	require := require.New(t)
+
+	ranges := convertRanges([]*hunk{&hunk{
+		OldStartLine: 132,
+		OldLines:     7,
+		NewStartLine: 132,
+		NewLines:     7,
+	}})
+
+	require.Equal([]*posRange{&posRange{
+		AbsStart: 132, AbsEnd: 139,
+		RelStart: 1, RelEnd: 8,
+	}}, ranges)
+
+	ranges = convertRanges([]*hunk{&hunk{
+		OldStartLine: 100,
+		OldLines:     7,
+		NewStartLine: 132,
+		NewLines:     7,
+	}, &hunk{
+		OldStartLine: 200,
+		OldLines:     10,
+		NewStartLine: 500,
+		NewLines:     10,
+	}})
+
+	require.Equal([]*posRange{&posRange{
+		AbsStart: 132, AbsEnd: 139,
+		RelStart: 1, RelEnd: 8,
+	}, &posRange{
+		AbsStart: 500, AbsEnd: 510,
+		RelStart: 9, RelEnd: 19,
+	}}, ranges)
+
+	ranges = convertRanges([]*hunk{&hunk{
+		OldStartLine: 0,
+		OldLines:     0,
+		NewStartLine: 1,
+		NewLines:     446,
+	}})
+
+	require.Equal([]*posRange{&posRange{
+		AbsStart: 1, AbsEnd: 447,
+		RelStart: 1, RelEnd: 447,
+	}}, ranges)
+}

--- a/provider/github/poster.go
+++ b/provider/github/poster.go
@@ -1,0 +1,187 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/src-d/lookout"
+
+	"github.com/google/go-github/github"
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var (
+	// ErrGitHubAPI signals an error while making a request to the GitHub API.
+	ErrGitHubAPI = errors.NewKind("github api error")
+	// ErrEventNotSupported signals that this provider does not support the
+	// given event for a given operation.
+	ErrEventNotSupported = errors.NewKind("event not supported")
+)
+
+// Poster posts comments as Pull Request Reviews.
+type Poster struct {
+	rc ReviewCreator
+	cc CommitsComparator
+}
+
+var _ lookout.Poster = &Poster{}
+
+// NewPoster creates a new poster given a GitHub API client.
+func NewPoster(rc ReviewCreator, cc CommitsComparator) *Poster {
+	return &Poster{rc: rc, cc: cc}
+}
+
+// Post posts comments as a Pull Request Review.
+// If the event is not a GitHub Pull Request, ErrEventNotSupported is returned.
+// If a GitHub API request fails, ErrGitHubAPI is returned.
+func (p *Poster) Post(ctx context.Context, e lookout.Event,
+	cs []*lookout.Comment) error {
+	switch ev := e.(type) {
+	case *lookout.PullRequestEvent:
+		if ev.Provider != Provider {
+			return ErrEventNotSupported.Wrap(
+				fmt.Errorf("unsupported provider: %s", ev.Provider))
+		}
+
+		return p.postPR(ctx, ev, cs)
+	default:
+		return ErrEventNotSupported.Wrap(fmt.Errorf("unsupported event type"))
+	}
+}
+
+func (p *Poster) postPR(ctx context.Context, e *lookout.PullRequestEvent,
+	cs []*lookout.Comment) error {
+
+	owner, repo, pr, err := p.validatePR(e)
+	if err != nil {
+		return err
+	}
+
+	// TODO: make this request lazily, only if there are comments using
+	// positions.
+	cc, resp, err := p.cc.CompareCommits(ctx, owner, repo,
+		e.Base.Hash,
+		e.Head.Hash)
+	if err = p.handleAPIError(resp, err); err != nil {
+		return err
+	}
+
+	dl := newDiffLines(cc)
+	review, err := createReviewRequest(cs, dl)
+	if err != nil {
+		return err
+	}
+
+	_, resp, err = p.rc.CreateReview(ctx, owner, repo, pr, review)
+	if err = p.handleAPIError(resp, err); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Poster) validatePR(
+	e *lookout.PullRequestEvent) (owner, repo string, pr int, err error) {
+
+	base := e.Base
+	owner, err = extractOwner(base)
+	if err != nil {
+		err = ErrEventNotSupported.Wrap(err)
+		return
+	}
+
+	repo, err = extractRepo(base)
+	if err != nil {
+		err = ErrEventNotSupported.Wrap(err)
+		return
+	}
+
+	pr, err = strconv.Atoi(e.InternalID)
+	if err != nil {
+		err = ErrEventNotSupported.Wrap(
+			fmt.Errorf("bad PR ID: %s", e.InternalID))
+		return
+	}
+
+	return
+}
+
+func (p *Poster) handleAPIError(resp *github.Response, err error) error {
+	if err != nil {
+		return ErrGitHubAPI.Wrap(err)
+	}
+
+	if resp.StatusCode == 200 {
+		return nil
+	}
+
+	return ErrGitHubAPI.Wrap(fmt.Errorf("bad HTTP status: %d", resp.StatusCode))
+}
+
+// ReviewCreator can create code reviews on GitHub. *github.PullRequestsService
+// fulfills this interface.
+type ReviewCreator interface {
+	// CreateReview creates a new code review on a GitHub pull request.
+	CreateReview(ctx context.Context, owner, repo string,
+		number int, review *github.PullRequestReviewRequest) (
+		*github.PullRequestReview, *github.Response, error)
+}
+
+var _ ReviewCreator = &github.PullRequestsService{}
+
+// CommitsComparator compares commits on GitHub. *github.RepositoriesService
+// fulfills this interface.
+type CommitsComparator interface {
+	// CompareCommits compare two commits.
+	CompareCommits(ctx context.Context, owner, repo string, base, head string) (
+		*github.CommitsComparison, *github.Response, error)
+}
+
+var _ CommitsComparator = &github.RepositoriesService{}
+
+var approveEvent = "APPROVE"
+
+func createReviewRequest(
+	cs []*lookout.Comment,
+	dl *diffLines) (*github.PullRequestReviewRequest, error) {
+	req := &github.PullRequestReviewRequest{
+		Event: &approveEvent,
+	}
+
+	var bodyComments []string
+
+	for _, c := range cs {
+		if c.File == "" {
+			bodyComments = append(bodyComments, c.Text)
+		} else if c.Line < 1 {
+			line := 1
+			comment := &github.DraftReviewComment{
+				Path:     &c.File,
+				Position: &line,
+				Body:     &c.Text,
+			}
+			req.Comments = append(req.Comments, comment)
+		} else {
+			line, err := dl.ConvertLine(c.File, int(c.Line))
+			if err != nil {
+				return nil, err
+			}
+
+			comment := &github.DraftReviewComment{
+				Path:     &c.File,
+				Position: &line,
+				Body:     &c.Text,
+			}
+			req.Comments = append(req.Comments, comment)
+		}
+	}
+
+	if len(bodyComments) > 0 {
+		body := strings.Join(bodyComments, "\n\n")
+		req.Body = &body
+	}
+
+	return req, nil
+}

--- a/provider/github/poster_test.go
+++ b/provider/github/poster_test.go
@@ -1,0 +1,254 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/src-d/lookout"
+
+	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+var (
+	hash1 = "f67e5455a86d0f2a366f1b980489fac77a373bd0"
+	hash2 = "02801e1a27a0a906d59530aeb81f4cd137f2c717"
+	base1 = plumbing.ReferenceName("base")
+	head1 = plumbing.ReferenceName("head")
+)
+
+func TestPoster_Post_OK(t *testing.T) {
+	require := require.New(t)
+
+	mcc := &commitsComparator{}
+	mcc.On(
+		"CompareCommits",
+		mock.Anything, "foo", "bar", hash1, hash2).Once().Return(
+		&github.CommitsComparison{
+			Files: []github.CommitFile{github.CommitFile{
+				Filename: strptr("main.go"),
+				Patch:    strptr("@@ -3,10 +3,10 @@"),
+			}}},
+		&github.Response{Response: &http.Response{StatusCode: 200}},
+		nil)
+
+	mrc := &reviewCreator{}
+	mrc.On(
+		"CreateReview",
+		mock.Anything, "foo", "bar", 42,
+		&github.PullRequestReviewRequest{
+			Body:  strptr("Global comment\n\nAnother global comment"),
+			Event: strptr("APPROVE"),
+			Comments: []*github.DraftReviewComment{&github.DraftReviewComment{
+				Path:     strptr("main.go"),
+				Body:     strptr("File comment"),
+				Position: intptr(1),
+			}, &github.DraftReviewComment{
+				Path:     strptr("main.go"),
+				Position: intptr(3),
+				Body:     strptr("Line comment"),
+			}}},
+	).Once().Return(
+		nil,
+		&github.Response{Response: &http.Response{StatusCode: 200}},
+		nil)
+
+	p := NewPoster(mrc, mcc)
+	ev := &lookout.PullRequestEvent{
+		Provider:   Provider,
+		InternalID: "42",
+		CommitRevision: lookout.CommitRevision{
+			Base: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+				ReferenceName:         base1,
+				Hash:                  hash1,
+			},
+			Head: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+				ReferenceName:         head1,
+				Hash:                  hash2,
+			}}}
+	cs := []*lookout.Comment{&lookout.Comment{
+		Text: "Global comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Text: "File comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Line: 5,
+		Text: "Line comment",
+	}, &lookout.Comment{
+		Text: "Another global comment",
+	}}
+
+	err := p.Post(context.Background(), ev, cs)
+	require.NoError(err)
+
+	mcc.AssertExpectations(t)
+	mrc.AssertExpectations(t)
+}
+
+func TestPoster_Post_BadProvider(t *testing.T) {
+	require := require.New(t)
+
+	mcc := &commitsComparator{}
+	mrc := &reviewCreator{}
+	p := NewPoster(mrc, mcc)
+	ev := &lookout.PullRequestEvent{
+		Provider:   "badprovider",
+		InternalID: "42",
+		CommitRevision: lookout.CommitRevision{
+			Base: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+			}}}
+	cs := []*lookout.Comment{&lookout.Comment{
+		Text: "Global comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Text: "File comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Line: 5,
+		Text: "Line comment",
+	}, &lookout.Comment{
+		Text: "Another global comment",
+	}}
+
+	err := p.Post(context.Background(), ev, cs)
+	require.True(ErrEventNotSupported.Is(err))
+	require.Equal(
+		"event not supported: unsupported provider: badprovider", err.Error())
+
+	mcc.AssertExpectations(t)
+	mrc.AssertExpectations(t)
+}
+
+func TestPoster_Post_BadReferenceNoRepository(t *testing.T) {
+	require := require.New(t)
+
+	mcc := &commitsComparator{}
+	mrc := &reviewCreator{}
+	p := NewPoster(mrc, mcc)
+	ev := &lookout.PullRequestEvent{
+		Provider:   Provider,
+		InternalID: "42",
+	}
+	cs := []*lookout.Comment{&lookout.Comment{
+		Text: "Global comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Text: "File comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Line: 5,
+		Text: "Line comment",
+	}, &lookout.Comment{
+		Text: "Another global comment",
+	}}
+
+	err := p.Post(context.Background(), ev, cs)
+	require.True(ErrEventNotSupported.Is(err))
+	require.Equal(
+		"event not supported: nil repository", err.Error())
+
+	mcc.AssertExpectations(t)
+	mrc.AssertExpectations(t)
+}
+
+func TestPoster_Post_BadInternalID(t *testing.T) {
+	require := require.New(t)
+
+	mcc := &commitsComparator{}
+	mrc := &reviewCreator{}
+	p := NewPoster(mrc, mcc)
+	ev := &lookout.PullRequestEvent{
+		Provider:   Provider,
+		InternalID: "badid",
+		CommitRevision: lookout.CommitRevision{
+			Base: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+			}}}
+	cs := []*lookout.Comment{&lookout.Comment{
+		Text: "Global comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Text: "File comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Line: 5,
+		Text: "Line comment",
+	}, &lookout.Comment{
+		Text: "Another global comment",
+	}}
+
+	err := p.Post(context.Background(), ev, cs)
+	require.True(ErrEventNotSupported.Is(err))
+	require.Equal(
+		"event not supported: bad PR ID: badid", err.Error())
+
+	mcc.AssertExpectations(t)
+	mrc.AssertExpectations(t)
+}
+
+func strptr(v string) *string {
+	return &v
+}
+
+func intptr(v int) *int {
+	return &v
+}
+
+type reviewCreator struct {
+	mock.Mock
+}
+
+func (m *reviewCreator) CreateReview(ctx context.Context, owner, repo string,
+	number int, review *github.PullRequestReviewRequest) (
+	*github.PullRequestReview, *github.Response, error) {
+
+	args := m.Called(ctx, owner, repo, number, review)
+
+	var (
+		r0 *github.PullRequestReview
+		r1 *github.Response
+	)
+
+	if v := args.Get(0); v != nil {
+		r0 = v.(*github.PullRequestReview)
+	}
+
+	if v := args.Get(1); v != nil {
+		r1 = v.(*github.Response)
+	}
+
+	return r0, r1, args.Error(2)
+}
+
+type commitsComparator struct {
+	mock.Mock
+}
+
+func (m *commitsComparator) CompareCommits(ctx context.Context,
+	owner, repo string, base, head string) (
+	*github.CommitsComparison, *github.Response, error) {
+
+	args := m.Called(ctx, owner, repo, base, head)
+
+	var (
+		r0 *github.CommitsComparison
+		r1 *github.Response
+	)
+
+	if v := args.Get(0); v != nil {
+		r0 = v.(*github.CommitsComparison)
+	}
+
+	if v := args.Get(1); v != nil {
+		r1 = v.(*github.Response)
+	}
+
+	return r0, r1, args.Error(2)
+}

--- a/provider/github/utils.go
+++ b/provider/github/utils.go
@@ -123,3 +123,31 @@ func castPullRequestBranch(b *github.PullRequestBranch) lookout.ReferencePointer
 		Hash:                  b.GetSHA(),
 	}
 }
+
+func extractOwner(ref lookout.ReferencePointer) (owner string, err error) {
+	if ref.Repository() == nil {
+		err = fmt.Errorf("nil repository")
+		return
+	}
+
+	owner = ref.Repository().Username
+	if owner == "" {
+		err = fmt.Errorf("empty owner")
+	}
+
+	return
+}
+
+func extractRepo(ref lookout.ReferencePointer) (repo string, err error) {
+	if ref.Repository() == nil {
+		err = fmt.Errorf("nil repository")
+		return
+	}
+
+	repo = ref.Repository().Name
+	if repo == "" {
+		err = fmt.Errorf("empty repository name")
+	}
+
+	return
+}

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -40,7 +40,7 @@ type Watcher struct {
 }
 
 // NewWatcher returns a new
-func NewWatcher(o *lookout.WatchOptions) (*Watcher, error) {
+func NewWatcher(transport http.RoundTripper, o *lookout.WatchOptions) (*Watcher, error) {
 	r, err := vcsurl.Parse(o.URL)
 	if err != nil {
 		return nil, err
@@ -50,6 +50,7 @@ func NewWatcher(o *lookout.WatchOptions) (*Watcher, error) {
 
 	t := httpcache.NewTransport(cache)
 	t.MarkCachedResponses = true
+	t.Transport = transport
 
 	return &Watcher{
 		r: r,

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -36,7 +36,7 @@ type Watcher struct {
 	cache *cache.ValidableCache
 
 	// delay is time in seconds to wait between requests
-	poolInterval time.Duration
+	pollInterval time.Duration
 }
 
 // NewWatcher returns a new
@@ -84,7 +84,7 @@ func (w *Watcher) Watch(ctx context.Context, cb lookout.EventHandler) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(w.poolInterval):
+		case <-time.After(w.pollInterval):
 			continue
 		}
 	}
@@ -134,7 +134,7 @@ func (w *Watcher) doEventRequest(ctx context.Context, username, repository strin
 	}
 
 	secs, _ := strconv.Atoi(resp.Response.Header.Get("X-Poll-Interval"))
-	w.poolInterval = time.Duration(secs) * time.Second
+	w.pollInterval = time.Duration(secs) * time.Second
 
 	if isStatusNotModified(resp.Response) {
 		return nil, nil, NoErrNotModified.New()
@@ -143,7 +143,7 @@ func (w *Watcher) doEventRequest(ctx context.Context, username, repository strin
 	log.With(log.Fields{
 		"remaining-requests": resp.Rate.Remaining,
 		"reset-at":           resp.Rate.Reset,
-		"pool-interval":      w.poolInterval,
+		"poll-interval":      w.pollInterval,
 		"events":             len(events),
 	}).Debugf("Requested to events endpoint done.")
 

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -54,7 +54,7 @@ func (s *WatcherTestSuite) TestWatch() {
 		fmt.Fprint(w, `[{"id":"1", "type":"PushEvent", "payload":{"push_id": 1}}]`)
 	})
 
-	w, err := NewWatcher(&lookout.WatchOptions{
+	w, err := NewWatcher(nil, &lookout.WatchOptions{
 		URL: "github.com/mock/test",
 	})
 
@@ -84,7 +84,7 @@ func (s *WatcherTestSuite) TestWatch_WithError() {
 		fmt.Fprint(w, `[{"id":"1", "type":"PushEvent", "payload":{"push_id": 1}}]`)
 	})
 
-	w, err := NewWatcher(&lookout.WatchOptions{
+	w, err := NewWatcher(nil, &lookout.WatchOptions{
 		URL: "github.com/mock/test",
 	})
 

--- a/service/bblfsh/bblfsh_test.go
+++ b/service/bblfsh/bblfsh_test.go
@@ -101,7 +101,7 @@ func (s *ServiceSuite) TestNoContents() {
 	s.Mock.Nodes["f2old"] = &uast.Node{InternalType: "f2 old"}
 	s.Mock.Nodes["f2new"] = &uast.Node{InternalType: "f2 new"}
 
-	scan, err := srv.GetChanges(req)
+	scan, err := srv.GetChanges(context.TODO(), req)
 	require.NoError(err)
 	require.NotNil(scan)
 
@@ -163,7 +163,8 @@ type MockService struct {
 	Error           error
 }
 
-func (r *MockService) GetChanges(req *lookout.ChangesRequest) (
+func (r *MockService) GetChanges(ctx context.Context,
+	req *lookout.ChangesRequest) (
 	lookout.ChangeScanner, error) {
 	require := require.New(r.T)
 	require.Equal(r.ExpectedRequest, req)

--- a/service/git/examples_test.go
+++ b/service/git/examples_test.go
@@ -1,12 +1,12 @@
 package git
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/src-d/lookout"
 
 	"gopkg.in/src-d/go-git-fixtures.v3"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport/server"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
@@ -25,20 +25,18 @@ func Example() {
 
 	// Create the git service with a repository loader that allows it to find
 	// a repository by ID.
-	srv := NewService(server.MapLoader{
-		"file:///myrepo": storer,
-	})
-
-	changes, err := srv.GetChanges(&lookout.ChangesRequest{
-		Base: &lookout.ReferencePointer{
-			InternalRepositoryURL: "file:///myrepo",
-			Hash: "af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
-		},
-		Head: &lookout.ReferencePointer{
-			InternalRepositoryURL: "file:///myrepo",
-			Hash: "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
-		},
-	})
+	srv := NewService(&StorerCommitLoader{storer})
+	changes, err := srv.GetChanges(context.Background(),
+		&lookout.ChangesRequest{
+			Base: &lookout.ReferencePointer{
+				InternalRepositoryURL: "file:///myrepo",
+				Hash: "af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+			},
+			Head: &lookout.ReferencePointer{
+				InternalRepositoryURL: "file:///myrepo",
+				Hash: "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			},
+		})
 	if err != nil {
 		panic(err)
 	}

--- a/service/git/loader.go
+++ b/service/git/loader.go
@@ -1,0 +1,99 @@
+package git
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/src-d/lookout"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+)
+
+type CommitLoader interface {
+	LoadCommits(context.Context, ...lookout.ReferencePointer) (
+		[]*object.Commit, error)
+}
+
+type LibraryCommitLoader struct {
+	Library *Library
+	Syncer  *Syncer
+}
+
+func NewLibraryCommitLoader(l *Library, s *Syncer) *LibraryCommitLoader {
+	return &LibraryCommitLoader{
+		Library: l,
+		Syncer:  s,
+	}
+}
+
+func (l *LibraryCommitLoader) LoadCommits(
+	ctx context.Context, rps ...lookout.ReferencePointer) (
+	[]*object.Commit, error) {
+
+	if len(rps) == 0 {
+		return nil, nil
+	}
+
+	frp := rps[0]
+	for _, orp := range rps[1:] {
+		if orp.InternalRepositoryURL != frp.InternalRepositoryURL {
+			return nil, fmt.Errorf(
+				"loading commits from multiple repositories is not supported")
+		}
+	}
+
+	if err := l.Syncer.Sync(ctx, rps...); err != nil {
+		return nil, err
+	}
+
+	r, err := l.Library.GetOrInit(frp.Repository())
+	if err != nil {
+		return nil, err
+	}
+
+	commits := make([]*object.Commit, len(rps))
+	for i, rp := range rps {
+		commit, err := r.CommitObject(plumbing.NewHash(rp.Hash))
+		if err != nil {
+			return nil, err
+		}
+
+		commits[i] = commit
+	}
+
+	return commits, nil
+}
+
+type StorerCommitLoader struct {
+	Storer storer.Storer
+}
+
+func NewStorerCommitLoader(storer storer.Storer) *StorerCommitLoader {
+	return &StorerCommitLoader{
+		Storer: storer,
+	}
+}
+
+func (l *StorerCommitLoader) LoadCommits(ctx context.Context,
+	rps ...lookout.ReferencePointer) ([]*object.Commit, error) {
+
+	var commits []*object.Commit
+	for _, rp := range rps {
+		obj, err := l.Storer.EncodedObject(
+			plumbing.CommitObject, plumbing.NewHash(rp.Hash))
+		if err != nil {
+			return nil, err
+		}
+
+		commit, err := object.DecodeCommit(l.Storer, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		commits = append(commits, commit)
+	}
+
+	return commits, nil
+}

--- a/service/git/loader_test.go
+++ b/service/git/loader_test.go
@@ -1,0 +1,26 @@
+package git
+
+import (
+	"context"
+
+	"github.com/src-d/lookout"
+
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+type MockCommitLoader struct {
+	mock.Mock
+}
+
+func (m *MockCommitLoader) LoadCommits(ctx context.Context,
+	rps ...lookout.ReferencePointer) ([]*object.Commit, error) {
+
+	args := m.Called(ctx, rps)
+	r0 := args.Get(0)
+	if r0 == nil {
+		return nil, args.Error(1)
+	}
+
+	return r0.([]*object.Commit), args.Error(1)
+}

--- a/service/git/scanner_test.go
+++ b/service/git/scanner_test.go
@@ -64,7 +64,7 @@ func (s *ScannerSuite) TestTreeScanner() {
 	headTree, err := head.Tree()
 	require.NoError(err)
 
-	cs := NewTreeScanner(s.Storer, headTree)
+	cs := NewTreeScanner(headTree)
 	var changes []*lookout.Change
 	for cs.Next() {
 		changes = append(changes, cs.Change())
@@ -92,7 +92,7 @@ func (s *ScannerSuite) TestFilterScannerIncludeAll() {
 			require.NoError(err)
 
 			cs := NewFilterScanner(
-				NewTreeScanner(s.Storer, headTree),
+				NewTreeScanner(headTree),
 				fixture.IncludePattern, fixture.ExcludePattern,
 			)
 
@@ -125,7 +125,7 @@ func (s *ScannerSuite) TestFilterIncludeSome() {
 			require.NoError(err)
 
 			cs := NewFilterScanner(
-				NewTreeScanner(s.Storer, headTree),
+				NewTreeScanner(headTree),
 				fixture.IncludePattern, fixture.ExcludePattern,
 			)
 
@@ -158,7 +158,7 @@ func (s *ScannerSuite) TestFilterExcludeOne() {
 			require.NoError(err)
 
 			cs := NewFilterScanner(
-				NewTreeScanner(s.Storer, headTree),
+				NewTreeScanner(headTree),
 				fixture.IncludePattern, fixture.ExcludePattern,
 			)
 
@@ -184,8 +184,8 @@ func (s *ScannerSuite) TestBlobScanner() {
 	require.NoError(err)
 
 	cs := NewBlobScanner(
-		NewTreeScanner(s.Storer, headTree),
-		s.Storer,
+		NewTreeScanner(headTree),
+		nil, headTree,
 	)
 
 	changes := make(map[string]*lookout.Change)
@@ -221,7 +221,7 @@ func (s *ScannerSuite) TestDiffTreeScanner() {
 	parentTree, err := parent.Tree()
 	require.NoError(err)
 
-	cs := NewDiffTreeScanner(s.Storer, parentTree, headTree)
+	cs := NewDiffTreeScanner(parentTree, headTree)
 	var changes []*lookout.Change
 	for cs.Next() {
 		changes = append(changes, cs.Change())

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -53,9 +53,10 @@ func (s *Syncer) Sync(ctx context.Context,
 		Force:      true,
 	}
 
-	if err := r.FetchContext(ctx, opts); err != nil {
-		return err
+	err = r.FetchContext(ctx, opts)
+	if err == git.NoErrAlreadyUpToDate {
+		return nil
 	}
 
-	return nil
+	return err
 }

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -20,9 +20,9 @@ func NewSyncer(l *Library) *Syncer {
 	return &Syncer{l}
 }
 
-// Sync syncs the local git repository to the given commit revision.
-func (s *Syncer) Sync(ctx context.Context, rev *lookout.CommitRevision) error {
-	r, err := s.l.GetOrInit(rev.Head.Repository())
+// Sync syncs the local git repository to the given reference pointer.
+func (s *Syncer) Sync(ctx context.Context, rp lookout.ReferencePointer) error {
+	r, err := s.l.GetOrInit(rp.Repository())
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func (s *Syncer) Sync(ctx context.Context, rev *lookout.CommitRevision) error {
 	opts := &git.FetchOptions{
 		RemoteName: "origin",
 		RefSpecs: []config.RefSpec{
-			config.RefSpec(fmt.Sprintf("%s:%[1]s", rev.Head.ReferenceName)),
+			config.RefSpec(fmt.Sprintf("%s:%[1]s", rp.ReferenceName)),
 		},
 		Force: true,
 	}

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -20,24 +20,42 @@ func NewSyncer(l *Library) *Syncer {
 	return &Syncer{l}
 }
 
-// Sync syncs the local git repository to the given reference pointer.
-func (s *Syncer) Sync(ctx context.Context, rp lookout.ReferencePointer) error {
-	r, err := s.l.GetOrInit(rp.Repository())
+// Sync syncs the local git repository to the given reference pointers.
+func (s *Syncer) Sync(ctx context.Context,
+	rps ...lookout.ReferencePointer) error {
+
+	if len(rps) == 0 {
+		return fmt.Errorf("at least one reference pointer is required")
+	}
+
+	frp := rps[0]
+	for _, orp := range rps[1:] {
+		if orp.InternalRepositoryURL != frp.InternalRepositoryURL {
+			return fmt.Errorf(
+				"sync from multiple repositories is not supported")
+		}
+	}
+
+	r, err := s.l.GetOrInit(frp.Repository())
 	if err != nil {
 		return err
 	}
 
+	var refspecs []config.RefSpec
+	for _, rp := range rps {
+		rs := config.RefSpec(fmt.Sprintf("%s:%[1]s", rp.ReferenceName))
+		refspecs = append(refspecs, rs)
+	}
+
 	opts := &git.FetchOptions{
 		RemoteName: "origin",
-		RefSpecs: []config.RefSpec{
-			config.RefSpec(fmt.Sprintf("%s:%[1]s", rp.ReferenceName)),
-		},
-		Force: true,
+		RefSpecs:   refspecs,
+		Force:      true,
 	}
 
 	if err := r.FetchContext(ctx, opts); err != nil {
 		return err
 	}
 
-	return err
+	return nil
 }

--- a/service/git/syncer_test.go
+++ b/service/git/syncer_test.go
@@ -17,12 +17,10 @@ func TestLibrary_Sync(t *testing.T) {
 	syncer := NewSyncer(library)
 
 	url, _ := vcsurl.Parse("http://github.com/src-d/lookout")
-	err := syncer.Sync(context.TODO(), &lookout.CommitRevision{
-		Head: lookout.ReferencePointer{
-			InternalRepositoryURL: url.CloneURL,
-			ReferenceName:         "refs/pull/1/head",
-			Hash:                  "80a9810a027672a098b07efda3dc305409c9329d",
-		},
+	err := syncer.Sync(context.TODO(), lookout.ReferencePointer{
+		InternalRepositoryURL: url.CloneURL,
+		ReferenceName:         "refs/pull/1/head",
+		Hash:                  "80a9810a027672a098b07efda3dc305409c9329d",
 	})
 
 	require.NoError(err)

--- a/vendor/github.com/stretchr/objx/LICENSE
+++ b/vendor/github.com/stretchr/objx/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Stretchr, Inc.
+Copyright (c) 2017-2018 objx contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/stretchr/objx/accessors.go
+++ b/vendor/github.com/stretchr/objx/accessors.go
@@ -1,0 +1,148 @@
+package objx
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// arrayAccesRegexString is the regex used to extract the array number
+// from the access path
+const arrayAccesRegexString = `^(.+)\[([0-9]+)\]$`
+
+// arrayAccesRegex is the compiled arrayAccesRegexString
+var arrayAccesRegex = regexp.MustCompile(arrayAccesRegexString)
+
+// Get gets the value using the specified selector and
+// returns it inside a new Obj object.
+//
+// If it cannot find the value, Get will return a nil
+// value inside an instance of Obj.
+//
+// Get can only operate directly on map[string]interface{} and []interface.
+//
+// Example
+//
+// To access the title of the third chapter of the second book, do:
+//
+//    o.Get("books[1].chapters[2].title")
+func (m Map) Get(selector string) *Value {
+	rawObj := access(m, selector, nil, false)
+	return &Value{data: rawObj}
+}
+
+// Set sets the value using the specified selector and
+// returns the object on which Set was called.
+//
+// Set can only operate directly on map[string]interface{} and []interface
+//
+// Example
+//
+// To set the title of the third chapter of the second book, do:
+//
+//    o.Set("books[1].chapters[2].title","Time to Go")
+func (m Map) Set(selector string, value interface{}) Map {
+	access(m, selector, value, true)
+	return m
+}
+
+// access accesses the object using the selector and performs the
+// appropriate action.
+func access(current, selector, value interface{}, isSet bool) interface{} {
+	switch selector.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		if array, ok := current.([]interface{}); ok {
+			index := intFromInterface(selector)
+			if index >= len(array) {
+				return nil
+			}
+			return array[index]
+		}
+		return nil
+
+	case string:
+		selStr := selector.(string)
+		selSegs := strings.SplitN(selStr, PathSeparator, 2)
+		thisSel := selSegs[0]
+		index := -1
+		var err error
+
+		if strings.Contains(thisSel, "[") {
+			arrayMatches := arrayAccesRegex.FindStringSubmatch(thisSel)
+			if len(arrayMatches) > 0 {
+				// Get the key into the map
+				thisSel = arrayMatches[1]
+
+				// Get the index into the array at the key
+				index, err = strconv.Atoi(arrayMatches[2])
+
+				if err != nil {
+					// This should never happen. If it does, something has gone
+					// seriously wrong. Panic.
+					panic("objx: Array index is not an integer.  Must use array[int].")
+				}
+			}
+		}
+		if curMap, ok := current.(Map); ok {
+			current = map[string]interface{}(curMap)
+		}
+		// get the object in question
+		switch current.(type) {
+		case map[string]interface{}:
+			curMSI := current.(map[string]interface{})
+			if len(selSegs) <= 1 && isSet {
+				curMSI[thisSel] = value
+				return nil
+			}
+			current = curMSI[thisSel]
+		default:
+			current = nil
+		}
+		// do we need to access the item of an array?
+		if index > -1 {
+			if array, ok := current.([]interface{}); ok {
+				if index < len(array) {
+					current = array[index]
+				} else {
+					current = nil
+				}
+			}
+		}
+		if len(selSegs) > 1 {
+			current = access(current, selSegs[1], value, isSet)
+		}
+	}
+	return current
+}
+
+// intFromInterface converts an interface object to the largest
+// representation of an unsigned integer using a type switch and
+// assertions
+func intFromInterface(selector interface{}) int {
+	var value int
+	switch selector.(type) {
+	case int:
+		value = selector.(int)
+	case int8:
+		value = int(selector.(int8))
+	case int16:
+		value = int(selector.(int16))
+	case int32:
+		value = int(selector.(int32))
+	case int64:
+		value = int(selector.(int64))
+	case uint:
+		value = int(selector.(uint))
+	case uint8:
+		value = int(selector.(uint8))
+	case uint16:
+		value = int(selector.(uint16))
+	case uint32:
+		value = int(selector.(uint32))
+	case uint64:
+		value = int(selector.(uint64))
+	default:
+		return 0
+	}
+	return value
+}

--- a/vendor/github.com/stretchr/objx/constants.go
+++ b/vendor/github.com/stretchr/objx/constants.go
@@ -1,0 +1,13 @@
+package objx
+
+const (
+	// PathSeparator is the character used to separate the elements
+	// of the keypath.
+	//
+	// For example, `location.address.city`
+	PathSeparator string = "."
+
+	// SignatureSeparator is the character that is used to
+	// separate the Base64 string from the security signature.
+	SignatureSeparator = "_"
+)

--- a/vendor/github.com/stretchr/objx/conversions.go
+++ b/vendor/github.com/stretchr/objx/conversions.go
@@ -1,0 +1,108 @@
+package objx
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// JSON converts the contained object to a JSON string
+// representation
+func (m Map) JSON() (string, error) {
+	result, err := json.Marshal(m)
+	if err != nil {
+		err = errors.New("objx: JSON encode failed with: " + err.Error())
+	}
+	return string(result), err
+}
+
+// MustJSON converts the contained object to a JSON string
+// representation and panics if there is an error
+func (m Map) MustJSON() string {
+	result, err := m.JSON()
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+// Base64 converts the contained object to a Base64 string
+// representation of the JSON string representation
+func (m Map) Base64() (string, error) {
+	var buf bytes.Buffer
+
+	jsonData, err := m.JSON()
+	if err != nil {
+		return "", err
+	}
+
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+	_, err = encoder.Write([]byte(jsonData))
+	if err != nil {
+		return "", err
+	}
+	_ = encoder.Close()
+
+	return buf.String(), nil
+}
+
+// MustBase64 converts the contained object to a Base64 string
+// representation of the JSON string representation and panics
+// if there is an error
+func (m Map) MustBase64() string {
+	result, err := m.Base64()
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+// SignedBase64 converts the contained object to a Base64 string
+// representation of the JSON string representation and signs it
+// using the provided key.
+func (m Map) SignedBase64(key string) (string, error) {
+	base64, err := m.Base64()
+	if err != nil {
+		return "", err
+	}
+
+	sig := HashWithKey(base64, key)
+	return base64 + SignatureSeparator + sig, nil
+}
+
+// MustSignedBase64 converts the contained object to a Base64 string
+// representation of the JSON string representation and signs it
+// using the provided key and panics if there is an error
+func (m Map) MustSignedBase64(key string) string {
+	result, err := m.SignedBase64(key)
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+/*
+	URL Query
+	------------------------------------------------
+*/
+
+// URLValues creates a url.Values object from an Obj. This
+// function requires that the wrapped object be a map[string]interface{}
+func (m Map) URLValues() url.Values {
+	vals := make(url.Values)
+	for k, v := range m {
+		//TODO: can this be done without sprintf?
+		vals.Set(k, fmt.Sprintf("%v", v))
+	}
+	return vals
+}
+
+// URLQuery gets an encoded URL query representing the given
+// Obj. This function requires that the wrapped object be a
+// map[string]interface{}
+func (m Map) URLQuery() (string, error) {
+	return m.URLValues().Encode(), nil
+}

--- a/vendor/github.com/stretchr/objx/doc.go
+++ b/vendor/github.com/stretchr/objx/doc.go
@@ -1,0 +1,66 @@
+/*
+Objx - Go package for dealing with maps, slices, JSON and other data.
+
+Overview
+
+Objx provides the `objx.Map` type, which is a `map[string]interface{}` that exposes
+a powerful `Get` method (among others) that allows you to easily and quickly get
+access to data within the map, without having to worry too much about type assertions,
+missing data, default values etc.
+
+Pattern
+
+Objx uses a preditable pattern to make access data from within `map[string]interface{}` easy.
+Call one of the `objx.` functions to create your `objx.Map` to get going:
+
+    m, err := objx.FromJSON(json)
+
+NOTE: Any methods or functions with the `Must` prefix will panic if something goes wrong,
+the rest will be optimistic and try to figure things out without panicking.
+
+Use `Get` to access the value you're interested in.  You can use dot and array
+notation too:
+
+     m.Get("places[0].latlng")
+
+Once you have sought the `Value` you're interested in, you can use the `Is*` methods to determine its type.
+
+     if m.Get("code").IsStr() { // Your code... }
+
+Or you can just assume the type, and use one of the strong type methods to extract the real value:
+
+   m.Get("code").Int()
+
+If there's no value there (or if it's the wrong type) then a default value will be returned,
+or you can be explicit about the default value.
+
+     Get("code").Int(-1)
+
+If you're dealing with a slice of data as a value, Objx provides many useful methods for iterating,
+manipulating and selecting that data.  You can find out more by exploring the index below.
+
+Reading data
+
+A simple example of how to use Objx:
+
+   // Use MustFromJSON to make an objx.Map from some JSON
+   m := objx.MustFromJSON(`{"name": "Mat", "age": 30}`)
+
+   // Get the details
+   name := m.Get("name").Str()
+   age := m.Get("age").Int()
+
+   // Get their nickname (or use their name if they don't have one)
+   nickname := m.Get("nickname").Str(name)
+
+Ranging
+
+Since `objx.Map` is a `map[string]interface{}` you can treat it as such.
+For example, to `range` the data, do what you would expect:
+
+    m := objx.MustFromJSON(json)
+    for key, value := range m {
+      // Your code...
+    }
+*/
+package objx

--- a/vendor/github.com/stretchr/objx/map.go
+++ b/vendor/github.com/stretchr/objx/map.go
@@ -1,0 +1,190 @@
+package objx
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/url"
+	"strings"
+)
+
+// MSIConvertable is an interface that defines methods for converting your
+// custom types to a map[string]interface{} representation.
+type MSIConvertable interface {
+	// MSI gets a map[string]interface{} (msi) representing the
+	// object.
+	MSI() map[string]interface{}
+}
+
+// Map provides extended functionality for working with
+// untyped data, in particular map[string]interface (msi).
+type Map map[string]interface{}
+
+// Value returns the internal value instance
+func (m Map) Value() *Value {
+	return &Value{data: m}
+}
+
+// Nil represents a nil Map.
+var Nil = New(nil)
+
+// New creates a new Map containing the map[string]interface{} in the data argument.
+// If the data argument is not a map[string]interface, New attempts to call the
+// MSI() method on the MSIConvertable interface to create one.
+func New(data interface{}) Map {
+	if _, ok := data.(map[string]interface{}); !ok {
+		if converter, ok := data.(MSIConvertable); ok {
+			data = converter.MSI()
+		} else {
+			return nil
+		}
+	}
+	return Map(data.(map[string]interface{}))
+}
+
+// MSI creates a map[string]interface{} and puts it inside a new Map.
+//
+// The arguments follow a key, value pattern.
+//
+//
+// Returns nil if any key argument is non-string or if there are an odd number of arguments.
+//
+// Example
+//
+// To easily create Maps:
+//
+//     m := objx.MSI("name", "Mat", "age", 29, "subobj", objx.MSI("active", true))
+//
+//     // creates an Map equivalent to
+//     m := objx.Map{"name": "Mat", "age": 29, "subobj": objx.Map{"active": true}}
+func MSI(keyAndValuePairs ...interface{}) Map {
+	newMap := Map{}
+	keyAndValuePairsLen := len(keyAndValuePairs)
+	if keyAndValuePairsLen%2 != 0 {
+		return nil
+	}
+	for i := 0; i < keyAndValuePairsLen; i = i + 2 {
+		key := keyAndValuePairs[i]
+		value := keyAndValuePairs[i+1]
+
+		// make sure the key is a string
+		keyString, keyStringOK := key.(string)
+		if !keyStringOK {
+			return nil
+		}
+		newMap[keyString] = value
+	}
+	return newMap
+}
+
+// ****** Conversion Constructors
+
+// MustFromJSON creates a new Map containing the data specified in the
+// jsonString.
+//
+// Panics if the JSON is invalid.
+func MustFromJSON(jsonString string) Map {
+	o, err := FromJSON(jsonString)
+	if err != nil {
+		panic("objx: MustFromJSON failed with error: " + err.Error())
+	}
+	return o
+}
+
+// FromJSON creates a new Map containing the data specified in the
+// jsonString.
+//
+// Returns an error if the JSON is invalid.
+func FromJSON(jsonString string) (Map, error) {
+	var data interface{}
+	err := json.Unmarshal([]byte(jsonString), &data)
+	if err != nil {
+		return Nil, err
+	}
+	return New(data), nil
+}
+
+// FromBase64 creates a new Obj containing the data specified
+// in the Base64 string.
+//
+// The string is an encoded JSON string returned by Base64
+func FromBase64(base64String string) (Map, error) {
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(base64String))
+	decoded, err := ioutil.ReadAll(decoder)
+	if err != nil {
+		return nil, err
+	}
+	return FromJSON(string(decoded))
+}
+
+// MustFromBase64 creates a new Obj containing the data specified
+// in the Base64 string and panics if there is an error.
+//
+// The string is an encoded JSON string returned by Base64
+func MustFromBase64(base64String string) Map {
+	result, err := FromBase64(base64String)
+	if err != nil {
+		panic("objx: MustFromBase64 failed with error: " + err.Error())
+	}
+	return result
+}
+
+// FromSignedBase64 creates a new Obj containing the data specified
+// in the Base64 string.
+//
+// The string is an encoded JSON string returned by SignedBase64
+func FromSignedBase64(base64String, key string) (Map, error) {
+	parts := strings.Split(base64String, SignatureSeparator)
+	if len(parts) != 2 {
+		return nil, errors.New("objx: Signed base64 string is malformed")
+	}
+
+	sig := HashWithKey(parts[0], key)
+	if parts[1] != sig {
+		return nil, errors.New("objx: Signature for base64 data does not match")
+	}
+	return FromBase64(parts[0])
+}
+
+// MustFromSignedBase64 creates a new Obj containing the data specified
+// in the Base64 string and panics if there is an error.
+//
+// The string is an encoded JSON string returned by Base64
+func MustFromSignedBase64(base64String, key string) Map {
+	result, err := FromSignedBase64(base64String, key)
+	if err != nil {
+		panic("objx: MustFromSignedBase64 failed with error: " + err.Error())
+	}
+	return result
+}
+
+// FromURLQuery generates a new Obj by parsing the specified
+// query.
+//
+// For queries with multiple values, the first value is selected.
+func FromURLQuery(query string) (Map, error) {
+	vals, err := url.ParseQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	m := Map{}
+	for k, vals := range vals {
+		m[k] = vals[0]
+	}
+	return m, nil
+}
+
+// MustFromURLQuery generates a new Obj by parsing the specified
+// query.
+//
+// For queries with multiple values, the first value is selected.
+//
+// Panics if it encounters an error
+func MustFromURLQuery(query string) Map {
+	o, err := FromURLQuery(query)
+	if err != nil {
+		panic("objx: MustFromURLQuery failed with error: " + err.Error())
+	}
+	return o
+}

--- a/vendor/github.com/stretchr/objx/mutations.go
+++ b/vendor/github.com/stretchr/objx/mutations.go
@@ -1,0 +1,77 @@
+package objx
+
+// Exclude returns a new Map with the keys in the specified []string
+// excluded.
+func (m Map) Exclude(exclude []string) Map {
+	excluded := make(Map)
+	for k, v := range m {
+		if !contains(exclude, k) {
+			excluded[k] = v
+		}
+	}
+	return excluded
+}
+
+// Copy creates a shallow copy of the Obj.
+func (m Map) Copy() Map {
+	copied := Map{}
+	for k, v := range m {
+		copied[k] = v
+	}
+	return copied
+}
+
+// Merge blends the specified map with a copy of this map and returns the result.
+//
+// Keys that appear in both will be selected from the specified map.
+// This method requires that the wrapped object be a map[string]interface{}
+func (m Map) Merge(merge Map) Map {
+	return m.Copy().MergeHere(merge)
+}
+
+// MergeHere blends the specified map with this map and returns the current map.
+//
+// Keys that appear in both will be selected from the specified map. The original map
+// will be modified. This method requires that
+// the wrapped object be a map[string]interface{}
+func (m Map) MergeHere(merge Map) Map {
+	for k, v := range merge {
+		m[k] = v
+	}
+	return m
+}
+
+// Transform builds a new Obj giving the transformer a chance
+// to change the keys and values as it goes. This method requires that
+// the wrapped object be a map[string]interface{}
+func (m Map) Transform(transformer func(key string, value interface{}) (string, interface{})) Map {
+	newMap := Map{}
+	for k, v := range m {
+		modifiedKey, modifiedVal := transformer(k, v)
+		newMap[modifiedKey] = modifiedVal
+	}
+	return newMap
+}
+
+// TransformKeys builds a new map using the specified key mapping.
+//
+// Unspecified keys will be unaltered.
+// This method requires that the wrapped object be a map[string]interface{}
+func (m Map) TransformKeys(mapping map[string]string) Map {
+	return m.Transform(func(key string, value interface{}) (string, interface{}) {
+		if newKey, ok := mapping[key]; ok {
+			return newKey, value
+		}
+		return key, value
+	})
+}
+
+// Checks if a string slice contains a string
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/stretchr/objx/security.go
+++ b/vendor/github.com/stretchr/objx/security.go
@@ -1,0 +1,12 @@
+package objx
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+)
+
+// HashWithKey hashes the specified string using the security key
+func HashWithKey(data, key string) string {
+	d := sha1.Sum([]byte(data + ":" + key))
+	return hex.EncodeToString(d[:])
+}

--- a/vendor/github.com/stretchr/objx/tests.go
+++ b/vendor/github.com/stretchr/objx/tests.go
@@ -1,0 +1,17 @@
+package objx
+
+// Has gets whether there is something at the specified selector
+// or not.
+//
+// If m is nil, Has will always return false.
+func (m Map) Has(selector string) bool {
+	if m == nil {
+		return false
+	}
+	return !m.Get(selector).IsNil()
+}
+
+// IsNil gets whether the data is nil or not.
+func (v *Value) IsNil() bool {
+	return v == nil || v.data == nil
+}

--- a/vendor/github.com/stretchr/objx/type_specific_codegen.go
+++ b/vendor/github.com/stretchr/objx/type_specific_codegen.go
@@ -1,0 +1,2501 @@
+package objx
+
+/*
+	Inter (interface{} and []interface{})
+*/
+
+// Inter gets the value as a interface{}, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Inter(optionalDefault ...interface{}) interface{} {
+	if s, ok := v.data.(interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInter gets the value as a interface{}.
+//
+// Panics if the object is not a interface{}.
+func (v *Value) MustInter() interface{} {
+	return v.data.(interface{})
+}
+
+// InterSlice gets the value as a []interface{}, returns the optionalDefault
+// value or nil if the value is not a []interface{}.
+func (v *Value) InterSlice(optionalDefault ...[]interface{}) []interface{} {
+	if s, ok := v.data.([]interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInterSlice gets the value as a []interface{}.
+//
+// Panics if the object is not a []interface{}.
+func (v *Value) MustInterSlice() []interface{} {
+	return v.data.([]interface{})
+}
+
+// IsInter gets whether the object contained is a interface{} or not.
+func (v *Value) IsInter() bool {
+	_, ok := v.data.(interface{})
+	return ok
+}
+
+// IsInterSlice gets whether the object contained is a []interface{} or not.
+func (v *Value) IsInterSlice() bool {
+	_, ok := v.data.([]interface{})
+	return ok
+}
+
+// EachInter calls the specified callback for each object
+// in the []interface{}.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInter(callback func(int, interface{}) bool) *Value {
+	for index, val := range v.MustInterSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInter uses the specified decider function to select items
+// from the []interface{}.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInter(decider func(int, interface{}) bool) *Value {
+	var selected []interface{}
+	v.EachInter(func(index int, val interface{}) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInter uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]interface{}.
+func (v *Value) GroupInter(grouper func(int, interface{}) string) *Value {
+	groups := make(map[string][]interface{})
+	v.EachInter(func(index int, val interface{}) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]interface{}, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInter uses the specified function to replace each interface{}s
+// by iterating each item.  The data in the returned result will be a
+// []interface{} containing the replaced items.
+func (v *Value) ReplaceInter(replacer func(int, interface{}) interface{}) *Value {
+	arr := v.MustInterSlice()
+	replaced := make([]interface{}, len(arr))
+	v.EachInter(func(index int, val interface{}) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInter uses the specified collector function to collect a value
+// for each of the interface{}s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInter(collector func(int, interface{}) interface{}) *Value {
+	arr := v.MustInterSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachInter(func(index int, val interface{}) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	MSI (map[string]interface{} and []map[string]interface{})
+*/
+
+// MSI gets the value as a map[string]interface{}, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) MSI(optionalDefault ...map[string]interface{}) map[string]interface{} {
+	if s, ok := v.data.(map[string]interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustMSI gets the value as a map[string]interface{}.
+//
+// Panics if the object is not a map[string]interface{}.
+func (v *Value) MustMSI() map[string]interface{} {
+	return v.data.(map[string]interface{})
+}
+
+// MSISlice gets the value as a []map[string]interface{}, returns the optionalDefault
+// value or nil if the value is not a []map[string]interface{}.
+func (v *Value) MSISlice(optionalDefault ...[]map[string]interface{}) []map[string]interface{} {
+	if s, ok := v.data.([]map[string]interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustMSISlice gets the value as a []map[string]interface{}.
+//
+// Panics if the object is not a []map[string]interface{}.
+func (v *Value) MustMSISlice() []map[string]interface{} {
+	return v.data.([]map[string]interface{})
+}
+
+// IsMSI gets whether the object contained is a map[string]interface{} or not.
+func (v *Value) IsMSI() bool {
+	_, ok := v.data.(map[string]interface{})
+	return ok
+}
+
+// IsMSISlice gets whether the object contained is a []map[string]interface{} or not.
+func (v *Value) IsMSISlice() bool {
+	_, ok := v.data.([]map[string]interface{})
+	return ok
+}
+
+// EachMSI calls the specified callback for each object
+// in the []map[string]interface{}.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachMSI(callback func(int, map[string]interface{}) bool) *Value {
+	for index, val := range v.MustMSISlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereMSI uses the specified decider function to select items
+// from the []map[string]interface{}.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereMSI(decider func(int, map[string]interface{}) bool) *Value {
+	var selected []map[string]interface{}
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupMSI uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]map[string]interface{}.
+func (v *Value) GroupMSI(grouper func(int, map[string]interface{}) string) *Value {
+	groups := make(map[string][]map[string]interface{})
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]map[string]interface{}, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceMSI uses the specified function to replace each map[string]interface{}s
+// by iterating each item.  The data in the returned result will be a
+// []map[string]interface{} containing the replaced items.
+func (v *Value) ReplaceMSI(replacer func(int, map[string]interface{}) map[string]interface{}) *Value {
+	arr := v.MustMSISlice()
+	replaced := make([]map[string]interface{}, len(arr))
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectMSI uses the specified collector function to collect a value
+// for each of the map[string]interface{}s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectMSI(collector func(int, map[string]interface{}) interface{}) *Value {
+	arr := v.MustMSISlice()
+	collected := make([]interface{}, len(arr))
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	ObjxMap ((Map) and [](Map))
+*/
+
+// ObjxMap gets the value as a (Map), returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) ObjxMap(optionalDefault ...(Map)) Map {
+	if s, ok := v.data.((Map)); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return New(nil)
+}
+
+// MustObjxMap gets the value as a (Map).
+//
+// Panics if the object is not a (Map).
+func (v *Value) MustObjxMap() Map {
+	return v.data.((Map))
+}
+
+// ObjxMapSlice gets the value as a [](Map), returns the optionalDefault
+// value or nil if the value is not a [](Map).
+func (v *Value) ObjxMapSlice(optionalDefault ...[](Map)) [](Map) {
+	if s, ok := v.data.([](Map)); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustObjxMapSlice gets the value as a [](Map).
+//
+// Panics if the object is not a [](Map).
+func (v *Value) MustObjxMapSlice() [](Map) {
+	return v.data.([](Map))
+}
+
+// IsObjxMap gets whether the object contained is a (Map) or not.
+func (v *Value) IsObjxMap() bool {
+	_, ok := v.data.((Map))
+	return ok
+}
+
+// IsObjxMapSlice gets whether the object contained is a [](Map) or not.
+func (v *Value) IsObjxMapSlice() bool {
+	_, ok := v.data.([](Map))
+	return ok
+}
+
+// EachObjxMap calls the specified callback for each object
+// in the [](Map).
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachObjxMap(callback func(int, Map) bool) *Value {
+	for index, val := range v.MustObjxMapSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereObjxMap uses the specified decider function to select items
+// from the [](Map).  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereObjxMap(decider func(int, Map) bool) *Value {
+	var selected [](Map)
+	v.EachObjxMap(func(index int, val Map) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupObjxMap uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][](Map).
+func (v *Value) GroupObjxMap(grouper func(int, Map) string) *Value {
+	groups := make(map[string][](Map))
+	v.EachObjxMap(func(index int, val Map) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([](Map), 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceObjxMap uses the specified function to replace each (Map)s
+// by iterating each item.  The data in the returned result will be a
+// [](Map) containing the replaced items.
+func (v *Value) ReplaceObjxMap(replacer func(int, Map) Map) *Value {
+	arr := v.MustObjxMapSlice()
+	replaced := make([](Map), len(arr))
+	v.EachObjxMap(func(index int, val Map) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectObjxMap uses the specified collector function to collect a value
+// for each of the (Map)s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectObjxMap(collector func(int, Map) interface{}) *Value {
+	arr := v.MustObjxMapSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachObjxMap(func(index int, val Map) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Bool (bool and []bool)
+*/
+
+// Bool gets the value as a bool, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Bool(optionalDefault ...bool) bool {
+	if s, ok := v.data.(bool); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return false
+}
+
+// MustBool gets the value as a bool.
+//
+// Panics if the object is not a bool.
+func (v *Value) MustBool() bool {
+	return v.data.(bool)
+}
+
+// BoolSlice gets the value as a []bool, returns the optionalDefault
+// value or nil if the value is not a []bool.
+func (v *Value) BoolSlice(optionalDefault ...[]bool) []bool {
+	if s, ok := v.data.([]bool); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustBoolSlice gets the value as a []bool.
+//
+// Panics if the object is not a []bool.
+func (v *Value) MustBoolSlice() []bool {
+	return v.data.([]bool)
+}
+
+// IsBool gets whether the object contained is a bool or not.
+func (v *Value) IsBool() bool {
+	_, ok := v.data.(bool)
+	return ok
+}
+
+// IsBoolSlice gets whether the object contained is a []bool or not.
+func (v *Value) IsBoolSlice() bool {
+	_, ok := v.data.([]bool)
+	return ok
+}
+
+// EachBool calls the specified callback for each object
+// in the []bool.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachBool(callback func(int, bool) bool) *Value {
+	for index, val := range v.MustBoolSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereBool uses the specified decider function to select items
+// from the []bool.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereBool(decider func(int, bool) bool) *Value {
+	var selected []bool
+	v.EachBool(func(index int, val bool) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupBool uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]bool.
+func (v *Value) GroupBool(grouper func(int, bool) string) *Value {
+	groups := make(map[string][]bool)
+	v.EachBool(func(index int, val bool) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]bool, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceBool uses the specified function to replace each bools
+// by iterating each item.  The data in the returned result will be a
+// []bool containing the replaced items.
+func (v *Value) ReplaceBool(replacer func(int, bool) bool) *Value {
+	arr := v.MustBoolSlice()
+	replaced := make([]bool, len(arr))
+	v.EachBool(func(index int, val bool) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectBool uses the specified collector function to collect a value
+// for each of the bools in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectBool(collector func(int, bool) interface{}) *Value {
+	arr := v.MustBoolSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachBool(func(index int, val bool) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Str (string and []string)
+*/
+
+// Str gets the value as a string, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Str(optionalDefault ...string) string {
+	if s, ok := v.data.(string); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return ""
+}
+
+// MustStr gets the value as a string.
+//
+// Panics if the object is not a string.
+func (v *Value) MustStr() string {
+	return v.data.(string)
+}
+
+// StrSlice gets the value as a []string, returns the optionalDefault
+// value or nil if the value is not a []string.
+func (v *Value) StrSlice(optionalDefault ...[]string) []string {
+	if s, ok := v.data.([]string); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustStrSlice gets the value as a []string.
+//
+// Panics if the object is not a []string.
+func (v *Value) MustStrSlice() []string {
+	return v.data.([]string)
+}
+
+// IsStr gets whether the object contained is a string or not.
+func (v *Value) IsStr() bool {
+	_, ok := v.data.(string)
+	return ok
+}
+
+// IsStrSlice gets whether the object contained is a []string or not.
+func (v *Value) IsStrSlice() bool {
+	_, ok := v.data.([]string)
+	return ok
+}
+
+// EachStr calls the specified callback for each object
+// in the []string.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachStr(callback func(int, string) bool) *Value {
+	for index, val := range v.MustStrSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereStr uses the specified decider function to select items
+// from the []string.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereStr(decider func(int, string) bool) *Value {
+	var selected []string
+	v.EachStr(func(index int, val string) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupStr uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]string.
+func (v *Value) GroupStr(grouper func(int, string) string) *Value {
+	groups := make(map[string][]string)
+	v.EachStr(func(index int, val string) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]string, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceStr uses the specified function to replace each strings
+// by iterating each item.  The data in the returned result will be a
+// []string containing the replaced items.
+func (v *Value) ReplaceStr(replacer func(int, string) string) *Value {
+	arr := v.MustStrSlice()
+	replaced := make([]string, len(arr))
+	v.EachStr(func(index int, val string) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectStr uses the specified collector function to collect a value
+// for each of the strings in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectStr(collector func(int, string) interface{}) *Value {
+	arr := v.MustStrSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachStr(func(index int, val string) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Int (int and []int)
+*/
+
+// Int gets the value as a int, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int(optionalDefault ...int) int {
+	if s, ok := v.data.(int); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt gets the value as a int.
+//
+// Panics if the object is not a int.
+func (v *Value) MustInt() int {
+	return v.data.(int)
+}
+
+// IntSlice gets the value as a []int, returns the optionalDefault
+// value or nil if the value is not a []int.
+func (v *Value) IntSlice(optionalDefault ...[]int) []int {
+	if s, ok := v.data.([]int); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustIntSlice gets the value as a []int.
+//
+// Panics if the object is not a []int.
+func (v *Value) MustIntSlice() []int {
+	return v.data.([]int)
+}
+
+// IsInt gets whether the object contained is a int or not.
+func (v *Value) IsInt() bool {
+	_, ok := v.data.(int)
+	return ok
+}
+
+// IsIntSlice gets whether the object contained is a []int or not.
+func (v *Value) IsIntSlice() bool {
+	_, ok := v.data.([]int)
+	return ok
+}
+
+// EachInt calls the specified callback for each object
+// in the []int.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt(callback func(int, int) bool) *Value {
+	for index, val := range v.MustIntSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt uses the specified decider function to select items
+// from the []int.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt(decider func(int, int) bool) *Value {
+	var selected []int
+	v.EachInt(func(index int, val int) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int.
+func (v *Value) GroupInt(grouper func(int, int) string) *Value {
+	groups := make(map[string][]int)
+	v.EachInt(func(index int, val int) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt uses the specified function to replace each ints
+// by iterating each item.  The data in the returned result will be a
+// []int containing the replaced items.
+func (v *Value) ReplaceInt(replacer func(int, int) int) *Value {
+	arr := v.MustIntSlice()
+	replaced := make([]int, len(arr))
+	v.EachInt(func(index int, val int) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt uses the specified collector function to collect a value
+// for each of the ints in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt(collector func(int, int) interface{}) *Value {
+	arr := v.MustIntSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt(func(index int, val int) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Int8 (int8 and []int8)
+*/
+
+// Int8 gets the value as a int8, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int8(optionalDefault ...int8) int8 {
+	if s, ok := v.data.(int8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt8 gets the value as a int8.
+//
+// Panics if the object is not a int8.
+func (v *Value) MustInt8() int8 {
+	return v.data.(int8)
+}
+
+// Int8Slice gets the value as a []int8, returns the optionalDefault
+// value or nil if the value is not a []int8.
+func (v *Value) Int8Slice(optionalDefault ...[]int8) []int8 {
+	if s, ok := v.data.([]int8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt8Slice gets the value as a []int8.
+//
+// Panics if the object is not a []int8.
+func (v *Value) MustInt8Slice() []int8 {
+	return v.data.([]int8)
+}
+
+// IsInt8 gets whether the object contained is a int8 or not.
+func (v *Value) IsInt8() bool {
+	_, ok := v.data.(int8)
+	return ok
+}
+
+// IsInt8Slice gets whether the object contained is a []int8 or not.
+func (v *Value) IsInt8Slice() bool {
+	_, ok := v.data.([]int8)
+	return ok
+}
+
+// EachInt8 calls the specified callback for each object
+// in the []int8.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt8(callback func(int, int8) bool) *Value {
+	for index, val := range v.MustInt8Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt8 uses the specified decider function to select items
+// from the []int8.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt8(decider func(int, int8) bool) *Value {
+	var selected []int8
+	v.EachInt8(func(index int, val int8) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt8 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int8.
+func (v *Value) GroupInt8(grouper func(int, int8) string) *Value {
+	groups := make(map[string][]int8)
+	v.EachInt8(func(index int, val int8) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int8, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt8 uses the specified function to replace each int8s
+// by iterating each item.  The data in the returned result will be a
+// []int8 containing the replaced items.
+func (v *Value) ReplaceInt8(replacer func(int, int8) int8) *Value {
+	arr := v.MustInt8Slice()
+	replaced := make([]int8, len(arr))
+	v.EachInt8(func(index int, val int8) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt8 uses the specified collector function to collect a value
+// for each of the int8s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt8(collector func(int, int8) interface{}) *Value {
+	arr := v.MustInt8Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt8(func(index int, val int8) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Int16 (int16 and []int16)
+*/
+
+// Int16 gets the value as a int16, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int16(optionalDefault ...int16) int16 {
+	if s, ok := v.data.(int16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt16 gets the value as a int16.
+//
+// Panics if the object is not a int16.
+func (v *Value) MustInt16() int16 {
+	return v.data.(int16)
+}
+
+// Int16Slice gets the value as a []int16, returns the optionalDefault
+// value or nil if the value is not a []int16.
+func (v *Value) Int16Slice(optionalDefault ...[]int16) []int16 {
+	if s, ok := v.data.([]int16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt16Slice gets the value as a []int16.
+//
+// Panics if the object is not a []int16.
+func (v *Value) MustInt16Slice() []int16 {
+	return v.data.([]int16)
+}
+
+// IsInt16 gets whether the object contained is a int16 or not.
+func (v *Value) IsInt16() bool {
+	_, ok := v.data.(int16)
+	return ok
+}
+
+// IsInt16Slice gets whether the object contained is a []int16 or not.
+func (v *Value) IsInt16Slice() bool {
+	_, ok := v.data.([]int16)
+	return ok
+}
+
+// EachInt16 calls the specified callback for each object
+// in the []int16.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt16(callback func(int, int16) bool) *Value {
+	for index, val := range v.MustInt16Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt16 uses the specified decider function to select items
+// from the []int16.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt16(decider func(int, int16) bool) *Value {
+	var selected []int16
+	v.EachInt16(func(index int, val int16) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt16 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int16.
+func (v *Value) GroupInt16(grouper func(int, int16) string) *Value {
+	groups := make(map[string][]int16)
+	v.EachInt16(func(index int, val int16) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int16, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt16 uses the specified function to replace each int16s
+// by iterating each item.  The data in the returned result will be a
+// []int16 containing the replaced items.
+func (v *Value) ReplaceInt16(replacer func(int, int16) int16) *Value {
+	arr := v.MustInt16Slice()
+	replaced := make([]int16, len(arr))
+	v.EachInt16(func(index int, val int16) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt16 uses the specified collector function to collect a value
+// for each of the int16s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt16(collector func(int, int16) interface{}) *Value {
+	arr := v.MustInt16Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt16(func(index int, val int16) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Int32 (int32 and []int32)
+*/
+
+// Int32 gets the value as a int32, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int32(optionalDefault ...int32) int32 {
+	if s, ok := v.data.(int32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt32 gets the value as a int32.
+//
+// Panics if the object is not a int32.
+func (v *Value) MustInt32() int32 {
+	return v.data.(int32)
+}
+
+// Int32Slice gets the value as a []int32, returns the optionalDefault
+// value or nil if the value is not a []int32.
+func (v *Value) Int32Slice(optionalDefault ...[]int32) []int32 {
+	if s, ok := v.data.([]int32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt32Slice gets the value as a []int32.
+//
+// Panics if the object is not a []int32.
+func (v *Value) MustInt32Slice() []int32 {
+	return v.data.([]int32)
+}
+
+// IsInt32 gets whether the object contained is a int32 or not.
+func (v *Value) IsInt32() bool {
+	_, ok := v.data.(int32)
+	return ok
+}
+
+// IsInt32Slice gets whether the object contained is a []int32 or not.
+func (v *Value) IsInt32Slice() bool {
+	_, ok := v.data.([]int32)
+	return ok
+}
+
+// EachInt32 calls the specified callback for each object
+// in the []int32.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt32(callback func(int, int32) bool) *Value {
+	for index, val := range v.MustInt32Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt32 uses the specified decider function to select items
+// from the []int32.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt32(decider func(int, int32) bool) *Value {
+	var selected []int32
+	v.EachInt32(func(index int, val int32) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt32 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int32.
+func (v *Value) GroupInt32(grouper func(int, int32) string) *Value {
+	groups := make(map[string][]int32)
+	v.EachInt32(func(index int, val int32) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int32, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt32 uses the specified function to replace each int32s
+// by iterating each item.  The data in the returned result will be a
+// []int32 containing the replaced items.
+func (v *Value) ReplaceInt32(replacer func(int, int32) int32) *Value {
+	arr := v.MustInt32Slice()
+	replaced := make([]int32, len(arr))
+	v.EachInt32(func(index int, val int32) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt32 uses the specified collector function to collect a value
+// for each of the int32s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt32(collector func(int, int32) interface{}) *Value {
+	arr := v.MustInt32Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt32(func(index int, val int32) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Int64 (int64 and []int64)
+*/
+
+// Int64 gets the value as a int64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int64(optionalDefault ...int64) int64 {
+	if s, ok := v.data.(int64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt64 gets the value as a int64.
+//
+// Panics if the object is not a int64.
+func (v *Value) MustInt64() int64 {
+	return v.data.(int64)
+}
+
+// Int64Slice gets the value as a []int64, returns the optionalDefault
+// value or nil if the value is not a []int64.
+func (v *Value) Int64Slice(optionalDefault ...[]int64) []int64 {
+	if s, ok := v.data.([]int64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt64Slice gets the value as a []int64.
+//
+// Panics if the object is not a []int64.
+func (v *Value) MustInt64Slice() []int64 {
+	return v.data.([]int64)
+}
+
+// IsInt64 gets whether the object contained is a int64 or not.
+func (v *Value) IsInt64() bool {
+	_, ok := v.data.(int64)
+	return ok
+}
+
+// IsInt64Slice gets whether the object contained is a []int64 or not.
+func (v *Value) IsInt64Slice() bool {
+	_, ok := v.data.([]int64)
+	return ok
+}
+
+// EachInt64 calls the specified callback for each object
+// in the []int64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt64(callback func(int, int64) bool) *Value {
+	for index, val := range v.MustInt64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt64 uses the specified decider function to select items
+// from the []int64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt64(decider func(int, int64) bool) *Value {
+	var selected []int64
+	v.EachInt64(func(index int, val int64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int64.
+func (v *Value) GroupInt64(grouper func(int, int64) string) *Value {
+	groups := make(map[string][]int64)
+	v.EachInt64(func(index int, val int64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt64 uses the specified function to replace each int64s
+// by iterating each item.  The data in the returned result will be a
+// []int64 containing the replaced items.
+func (v *Value) ReplaceInt64(replacer func(int, int64) int64) *Value {
+	arr := v.MustInt64Slice()
+	replaced := make([]int64, len(arr))
+	v.EachInt64(func(index int, val int64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt64 uses the specified collector function to collect a value
+// for each of the int64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt64(collector func(int, int64) interface{}) *Value {
+	arr := v.MustInt64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt64(func(index int, val int64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Uint (uint and []uint)
+*/
+
+// Uint gets the value as a uint, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint(optionalDefault ...uint) uint {
+	if s, ok := v.data.(uint); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint gets the value as a uint.
+//
+// Panics if the object is not a uint.
+func (v *Value) MustUint() uint {
+	return v.data.(uint)
+}
+
+// UintSlice gets the value as a []uint, returns the optionalDefault
+// value or nil if the value is not a []uint.
+func (v *Value) UintSlice(optionalDefault ...[]uint) []uint {
+	if s, ok := v.data.([]uint); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUintSlice gets the value as a []uint.
+//
+// Panics if the object is not a []uint.
+func (v *Value) MustUintSlice() []uint {
+	return v.data.([]uint)
+}
+
+// IsUint gets whether the object contained is a uint or not.
+func (v *Value) IsUint() bool {
+	_, ok := v.data.(uint)
+	return ok
+}
+
+// IsUintSlice gets whether the object contained is a []uint or not.
+func (v *Value) IsUintSlice() bool {
+	_, ok := v.data.([]uint)
+	return ok
+}
+
+// EachUint calls the specified callback for each object
+// in the []uint.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint(callback func(int, uint) bool) *Value {
+	for index, val := range v.MustUintSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint uses the specified decider function to select items
+// from the []uint.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint(decider func(int, uint) bool) *Value {
+	var selected []uint
+	v.EachUint(func(index int, val uint) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint.
+func (v *Value) GroupUint(grouper func(int, uint) string) *Value {
+	groups := make(map[string][]uint)
+	v.EachUint(func(index int, val uint) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint uses the specified function to replace each uints
+// by iterating each item.  The data in the returned result will be a
+// []uint containing the replaced items.
+func (v *Value) ReplaceUint(replacer func(int, uint) uint) *Value {
+	arr := v.MustUintSlice()
+	replaced := make([]uint, len(arr))
+	v.EachUint(func(index int, val uint) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint uses the specified collector function to collect a value
+// for each of the uints in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint(collector func(int, uint) interface{}) *Value {
+	arr := v.MustUintSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint(func(index int, val uint) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Uint8 (uint8 and []uint8)
+*/
+
+// Uint8 gets the value as a uint8, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint8(optionalDefault ...uint8) uint8 {
+	if s, ok := v.data.(uint8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint8 gets the value as a uint8.
+//
+// Panics if the object is not a uint8.
+func (v *Value) MustUint8() uint8 {
+	return v.data.(uint8)
+}
+
+// Uint8Slice gets the value as a []uint8, returns the optionalDefault
+// value or nil if the value is not a []uint8.
+func (v *Value) Uint8Slice(optionalDefault ...[]uint8) []uint8 {
+	if s, ok := v.data.([]uint8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint8Slice gets the value as a []uint8.
+//
+// Panics if the object is not a []uint8.
+func (v *Value) MustUint8Slice() []uint8 {
+	return v.data.([]uint8)
+}
+
+// IsUint8 gets whether the object contained is a uint8 or not.
+func (v *Value) IsUint8() bool {
+	_, ok := v.data.(uint8)
+	return ok
+}
+
+// IsUint8Slice gets whether the object contained is a []uint8 or not.
+func (v *Value) IsUint8Slice() bool {
+	_, ok := v.data.([]uint8)
+	return ok
+}
+
+// EachUint8 calls the specified callback for each object
+// in the []uint8.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint8(callback func(int, uint8) bool) *Value {
+	for index, val := range v.MustUint8Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint8 uses the specified decider function to select items
+// from the []uint8.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint8(decider func(int, uint8) bool) *Value {
+	var selected []uint8
+	v.EachUint8(func(index int, val uint8) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint8 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint8.
+func (v *Value) GroupUint8(grouper func(int, uint8) string) *Value {
+	groups := make(map[string][]uint8)
+	v.EachUint8(func(index int, val uint8) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint8, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint8 uses the specified function to replace each uint8s
+// by iterating each item.  The data in the returned result will be a
+// []uint8 containing the replaced items.
+func (v *Value) ReplaceUint8(replacer func(int, uint8) uint8) *Value {
+	arr := v.MustUint8Slice()
+	replaced := make([]uint8, len(arr))
+	v.EachUint8(func(index int, val uint8) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint8 uses the specified collector function to collect a value
+// for each of the uint8s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint8(collector func(int, uint8) interface{}) *Value {
+	arr := v.MustUint8Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint8(func(index int, val uint8) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Uint16 (uint16 and []uint16)
+*/
+
+// Uint16 gets the value as a uint16, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint16(optionalDefault ...uint16) uint16 {
+	if s, ok := v.data.(uint16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint16 gets the value as a uint16.
+//
+// Panics if the object is not a uint16.
+func (v *Value) MustUint16() uint16 {
+	return v.data.(uint16)
+}
+
+// Uint16Slice gets the value as a []uint16, returns the optionalDefault
+// value or nil if the value is not a []uint16.
+func (v *Value) Uint16Slice(optionalDefault ...[]uint16) []uint16 {
+	if s, ok := v.data.([]uint16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint16Slice gets the value as a []uint16.
+//
+// Panics if the object is not a []uint16.
+func (v *Value) MustUint16Slice() []uint16 {
+	return v.data.([]uint16)
+}
+
+// IsUint16 gets whether the object contained is a uint16 or not.
+func (v *Value) IsUint16() bool {
+	_, ok := v.data.(uint16)
+	return ok
+}
+
+// IsUint16Slice gets whether the object contained is a []uint16 or not.
+func (v *Value) IsUint16Slice() bool {
+	_, ok := v.data.([]uint16)
+	return ok
+}
+
+// EachUint16 calls the specified callback for each object
+// in the []uint16.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint16(callback func(int, uint16) bool) *Value {
+	for index, val := range v.MustUint16Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint16 uses the specified decider function to select items
+// from the []uint16.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint16(decider func(int, uint16) bool) *Value {
+	var selected []uint16
+	v.EachUint16(func(index int, val uint16) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint16 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint16.
+func (v *Value) GroupUint16(grouper func(int, uint16) string) *Value {
+	groups := make(map[string][]uint16)
+	v.EachUint16(func(index int, val uint16) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint16, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint16 uses the specified function to replace each uint16s
+// by iterating each item.  The data in the returned result will be a
+// []uint16 containing the replaced items.
+func (v *Value) ReplaceUint16(replacer func(int, uint16) uint16) *Value {
+	arr := v.MustUint16Slice()
+	replaced := make([]uint16, len(arr))
+	v.EachUint16(func(index int, val uint16) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint16 uses the specified collector function to collect a value
+// for each of the uint16s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint16(collector func(int, uint16) interface{}) *Value {
+	arr := v.MustUint16Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint16(func(index int, val uint16) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Uint32 (uint32 and []uint32)
+*/
+
+// Uint32 gets the value as a uint32, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint32(optionalDefault ...uint32) uint32 {
+	if s, ok := v.data.(uint32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint32 gets the value as a uint32.
+//
+// Panics if the object is not a uint32.
+func (v *Value) MustUint32() uint32 {
+	return v.data.(uint32)
+}
+
+// Uint32Slice gets the value as a []uint32, returns the optionalDefault
+// value or nil if the value is not a []uint32.
+func (v *Value) Uint32Slice(optionalDefault ...[]uint32) []uint32 {
+	if s, ok := v.data.([]uint32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint32Slice gets the value as a []uint32.
+//
+// Panics if the object is not a []uint32.
+func (v *Value) MustUint32Slice() []uint32 {
+	return v.data.([]uint32)
+}
+
+// IsUint32 gets whether the object contained is a uint32 or not.
+func (v *Value) IsUint32() bool {
+	_, ok := v.data.(uint32)
+	return ok
+}
+
+// IsUint32Slice gets whether the object contained is a []uint32 or not.
+func (v *Value) IsUint32Slice() bool {
+	_, ok := v.data.([]uint32)
+	return ok
+}
+
+// EachUint32 calls the specified callback for each object
+// in the []uint32.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint32(callback func(int, uint32) bool) *Value {
+	for index, val := range v.MustUint32Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint32 uses the specified decider function to select items
+// from the []uint32.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint32(decider func(int, uint32) bool) *Value {
+	var selected []uint32
+	v.EachUint32(func(index int, val uint32) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint32 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint32.
+func (v *Value) GroupUint32(grouper func(int, uint32) string) *Value {
+	groups := make(map[string][]uint32)
+	v.EachUint32(func(index int, val uint32) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint32, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint32 uses the specified function to replace each uint32s
+// by iterating each item.  The data in the returned result will be a
+// []uint32 containing the replaced items.
+func (v *Value) ReplaceUint32(replacer func(int, uint32) uint32) *Value {
+	arr := v.MustUint32Slice()
+	replaced := make([]uint32, len(arr))
+	v.EachUint32(func(index int, val uint32) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint32 uses the specified collector function to collect a value
+// for each of the uint32s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint32(collector func(int, uint32) interface{}) *Value {
+	arr := v.MustUint32Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint32(func(index int, val uint32) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Uint64 (uint64 and []uint64)
+*/
+
+// Uint64 gets the value as a uint64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint64(optionalDefault ...uint64) uint64 {
+	if s, ok := v.data.(uint64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint64 gets the value as a uint64.
+//
+// Panics if the object is not a uint64.
+func (v *Value) MustUint64() uint64 {
+	return v.data.(uint64)
+}
+
+// Uint64Slice gets the value as a []uint64, returns the optionalDefault
+// value or nil if the value is not a []uint64.
+func (v *Value) Uint64Slice(optionalDefault ...[]uint64) []uint64 {
+	if s, ok := v.data.([]uint64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint64Slice gets the value as a []uint64.
+//
+// Panics if the object is not a []uint64.
+func (v *Value) MustUint64Slice() []uint64 {
+	return v.data.([]uint64)
+}
+
+// IsUint64 gets whether the object contained is a uint64 or not.
+func (v *Value) IsUint64() bool {
+	_, ok := v.data.(uint64)
+	return ok
+}
+
+// IsUint64Slice gets whether the object contained is a []uint64 or not.
+func (v *Value) IsUint64Slice() bool {
+	_, ok := v.data.([]uint64)
+	return ok
+}
+
+// EachUint64 calls the specified callback for each object
+// in the []uint64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint64(callback func(int, uint64) bool) *Value {
+	for index, val := range v.MustUint64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint64 uses the specified decider function to select items
+// from the []uint64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint64(decider func(int, uint64) bool) *Value {
+	var selected []uint64
+	v.EachUint64(func(index int, val uint64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint64.
+func (v *Value) GroupUint64(grouper func(int, uint64) string) *Value {
+	groups := make(map[string][]uint64)
+	v.EachUint64(func(index int, val uint64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint64 uses the specified function to replace each uint64s
+// by iterating each item.  The data in the returned result will be a
+// []uint64 containing the replaced items.
+func (v *Value) ReplaceUint64(replacer func(int, uint64) uint64) *Value {
+	arr := v.MustUint64Slice()
+	replaced := make([]uint64, len(arr))
+	v.EachUint64(func(index int, val uint64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint64 uses the specified collector function to collect a value
+// for each of the uint64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint64(collector func(int, uint64) interface{}) *Value {
+	arr := v.MustUint64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint64(func(index int, val uint64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Uintptr (uintptr and []uintptr)
+*/
+
+// Uintptr gets the value as a uintptr, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uintptr(optionalDefault ...uintptr) uintptr {
+	if s, ok := v.data.(uintptr); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUintptr gets the value as a uintptr.
+//
+// Panics if the object is not a uintptr.
+func (v *Value) MustUintptr() uintptr {
+	return v.data.(uintptr)
+}
+
+// UintptrSlice gets the value as a []uintptr, returns the optionalDefault
+// value or nil if the value is not a []uintptr.
+func (v *Value) UintptrSlice(optionalDefault ...[]uintptr) []uintptr {
+	if s, ok := v.data.([]uintptr); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUintptrSlice gets the value as a []uintptr.
+//
+// Panics if the object is not a []uintptr.
+func (v *Value) MustUintptrSlice() []uintptr {
+	return v.data.([]uintptr)
+}
+
+// IsUintptr gets whether the object contained is a uintptr or not.
+func (v *Value) IsUintptr() bool {
+	_, ok := v.data.(uintptr)
+	return ok
+}
+
+// IsUintptrSlice gets whether the object contained is a []uintptr or not.
+func (v *Value) IsUintptrSlice() bool {
+	_, ok := v.data.([]uintptr)
+	return ok
+}
+
+// EachUintptr calls the specified callback for each object
+// in the []uintptr.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUintptr(callback func(int, uintptr) bool) *Value {
+	for index, val := range v.MustUintptrSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUintptr uses the specified decider function to select items
+// from the []uintptr.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUintptr(decider func(int, uintptr) bool) *Value {
+	var selected []uintptr
+	v.EachUintptr(func(index int, val uintptr) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUintptr uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uintptr.
+func (v *Value) GroupUintptr(grouper func(int, uintptr) string) *Value {
+	groups := make(map[string][]uintptr)
+	v.EachUintptr(func(index int, val uintptr) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uintptr, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUintptr uses the specified function to replace each uintptrs
+// by iterating each item.  The data in the returned result will be a
+// []uintptr containing the replaced items.
+func (v *Value) ReplaceUintptr(replacer func(int, uintptr) uintptr) *Value {
+	arr := v.MustUintptrSlice()
+	replaced := make([]uintptr, len(arr))
+	v.EachUintptr(func(index int, val uintptr) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUintptr uses the specified collector function to collect a value
+// for each of the uintptrs in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUintptr(collector func(int, uintptr) interface{}) *Value {
+	arr := v.MustUintptrSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachUintptr(func(index int, val uintptr) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Float32 (float32 and []float32)
+*/
+
+// Float32 gets the value as a float32, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Float32(optionalDefault ...float32) float32 {
+	if s, ok := v.data.(float32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustFloat32 gets the value as a float32.
+//
+// Panics if the object is not a float32.
+func (v *Value) MustFloat32() float32 {
+	return v.data.(float32)
+}
+
+// Float32Slice gets the value as a []float32, returns the optionalDefault
+// value or nil if the value is not a []float32.
+func (v *Value) Float32Slice(optionalDefault ...[]float32) []float32 {
+	if s, ok := v.data.([]float32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustFloat32Slice gets the value as a []float32.
+//
+// Panics if the object is not a []float32.
+func (v *Value) MustFloat32Slice() []float32 {
+	return v.data.([]float32)
+}
+
+// IsFloat32 gets whether the object contained is a float32 or not.
+func (v *Value) IsFloat32() bool {
+	_, ok := v.data.(float32)
+	return ok
+}
+
+// IsFloat32Slice gets whether the object contained is a []float32 or not.
+func (v *Value) IsFloat32Slice() bool {
+	_, ok := v.data.([]float32)
+	return ok
+}
+
+// EachFloat32 calls the specified callback for each object
+// in the []float32.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachFloat32(callback func(int, float32) bool) *Value {
+	for index, val := range v.MustFloat32Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereFloat32 uses the specified decider function to select items
+// from the []float32.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereFloat32(decider func(int, float32) bool) *Value {
+	var selected []float32
+	v.EachFloat32(func(index int, val float32) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupFloat32 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]float32.
+func (v *Value) GroupFloat32(grouper func(int, float32) string) *Value {
+	groups := make(map[string][]float32)
+	v.EachFloat32(func(index int, val float32) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]float32, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceFloat32 uses the specified function to replace each float32s
+// by iterating each item.  The data in the returned result will be a
+// []float32 containing the replaced items.
+func (v *Value) ReplaceFloat32(replacer func(int, float32) float32) *Value {
+	arr := v.MustFloat32Slice()
+	replaced := make([]float32, len(arr))
+	v.EachFloat32(func(index int, val float32) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectFloat32 uses the specified collector function to collect a value
+// for each of the float32s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectFloat32(collector func(int, float32) interface{}) *Value {
+	arr := v.MustFloat32Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachFloat32(func(index int, val float32) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Float64 (float64 and []float64)
+*/
+
+// Float64 gets the value as a float64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Float64(optionalDefault ...float64) float64 {
+	if s, ok := v.data.(float64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustFloat64 gets the value as a float64.
+//
+// Panics if the object is not a float64.
+func (v *Value) MustFloat64() float64 {
+	return v.data.(float64)
+}
+
+// Float64Slice gets the value as a []float64, returns the optionalDefault
+// value or nil if the value is not a []float64.
+func (v *Value) Float64Slice(optionalDefault ...[]float64) []float64 {
+	if s, ok := v.data.([]float64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustFloat64Slice gets the value as a []float64.
+//
+// Panics if the object is not a []float64.
+func (v *Value) MustFloat64Slice() []float64 {
+	return v.data.([]float64)
+}
+
+// IsFloat64 gets whether the object contained is a float64 or not.
+func (v *Value) IsFloat64() bool {
+	_, ok := v.data.(float64)
+	return ok
+}
+
+// IsFloat64Slice gets whether the object contained is a []float64 or not.
+func (v *Value) IsFloat64Slice() bool {
+	_, ok := v.data.([]float64)
+	return ok
+}
+
+// EachFloat64 calls the specified callback for each object
+// in the []float64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachFloat64(callback func(int, float64) bool) *Value {
+	for index, val := range v.MustFloat64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereFloat64 uses the specified decider function to select items
+// from the []float64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereFloat64(decider func(int, float64) bool) *Value {
+	var selected []float64
+	v.EachFloat64(func(index int, val float64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupFloat64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]float64.
+func (v *Value) GroupFloat64(grouper func(int, float64) string) *Value {
+	groups := make(map[string][]float64)
+	v.EachFloat64(func(index int, val float64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]float64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceFloat64 uses the specified function to replace each float64s
+// by iterating each item.  The data in the returned result will be a
+// []float64 containing the replaced items.
+func (v *Value) ReplaceFloat64(replacer func(int, float64) float64) *Value {
+	arr := v.MustFloat64Slice()
+	replaced := make([]float64, len(arr))
+	v.EachFloat64(func(index int, val float64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectFloat64 uses the specified collector function to collect a value
+// for each of the float64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectFloat64(collector func(int, float64) interface{}) *Value {
+	arr := v.MustFloat64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachFloat64(func(index int, val float64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Complex64 (complex64 and []complex64)
+*/
+
+// Complex64 gets the value as a complex64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Complex64(optionalDefault ...complex64) complex64 {
+	if s, ok := v.data.(complex64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustComplex64 gets the value as a complex64.
+//
+// Panics if the object is not a complex64.
+func (v *Value) MustComplex64() complex64 {
+	return v.data.(complex64)
+}
+
+// Complex64Slice gets the value as a []complex64, returns the optionalDefault
+// value or nil if the value is not a []complex64.
+func (v *Value) Complex64Slice(optionalDefault ...[]complex64) []complex64 {
+	if s, ok := v.data.([]complex64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustComplex64Slice gets the value as a []complex64.
+//
+// Panics if the object is not a []complex64.
+func (v *Value) MustComplex64Slice() []complex64 {
+	return v.data.([]complex64)
+}
+
+// IsComplex64 gets whether the object contained is a complex64 or not.
+func (v *Value) IsComplex64() bool {
+	_, ok := v.data.(complex64)
+	return ok
+}
+
+// IsComplex64Slice gets whether the object contained is a []complex64 or not.
+func (v *Value) IsComplex64Slice() bool {
+	_, ok := v.data.([]complex64)
+	return ok
+}
+
+// EachComplex64 calls the specified callback for each object
+// in the []complex64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachComplex64(callback func(int, complex64) bool) *Value {
+	for index, val := range v.MustComplex64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereComplex64 uses the specified decider function to select items
+// from the []complex64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereComplex64(decider func(int, complex64) bool) *Value {
+	var selected []complex64
+	v.EachComplex64(func(index int, val complex64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupComplex64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]complex64.
+func (v *Value) GroupComplex64(grouper func(int, complex64) string) *Value {
+	groups := make(map[string][]complex64)
+	v.EachComplex64(func(index int, val complex64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]complex64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceComplex64 uses the specified function to replace each complex64s
+// by iterating each item.  The data in the returned result will be a
+// []complex64 containing the replaced items.
+func (v *Value) ReplaceComplex64(replacer func(int, complex64) complex64) *Value {
+	arr := v.MustComplex64Slice()
+	replaced := make([]complex64, len(arr))
+	v.EachComplex64(func(index int, val complex64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectComplex64 uses the specified collector function to collect a value
+// for each of the complex64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectComplex64(collector func(int, complex64) interface{}) *Value {
+	arr := v.MustComplex64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachComplex64(func(index int, val complex64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+	Complex128 (complex128 and []complex128)
+*/
+
+// Complex128 gets the value as a complex128, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Complex128(optionalDefault ...complex128) complex128 {
+	if s, ok := v.data.(complex128); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustComplex128 gets the value as a complex128.
+//
+// Panics if the object is not a complex128.
+func (v *Value) MustComplex128() complex128 {
+	return v.data.(complex128)
+}
+
+// Complex128Slice gets the value as a []complex128, returns the optionalDefault
+// value or nil if the value is not a []complex128.
+func (v *Value) Complex128Slice(optionalDefault ...[]complex128) []complex128 {
+	if s, ok := v.data.([]complex128); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustComplex128Slice gets the value as a []complex128.
+//
+// Panics if the object is not a []complex128.
+func (v *Value) MustComplex128Slice() []complex128 {
+	return v.data.([]complex128)
+}
+
+// IsComplex128 gets whether the object contained is a complex128 or not.
+func (v *Value) IsComplex128() bool {
+	_, ok := v.data.(complex128)
+	return ok
+}
+
+// IsComplex128Slice gets whether the object contained is a []complex128 or not.
+func (v *Value) IsComplex128Slice() bool {
+	_, ok := v.data.([]complex128)
+	return ok
+}
+
+// EachComplex128 calls the specified callback for each object
+// in the []complex128.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachComplex128(callback func(int, complex128) bool) *Value {
+	for index, val := range v.MustComplex128Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereComplex128 uses the specified decider function to select items
+// from the []complex128.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereComplex128(decider func(int, complex128) bool) *Value {
+	var selected []complex128
+	v.EachComplex128(func(index int, val complex128) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupComplex128 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]complex128.
+func (v *Value) GroupComplex128(grouper func(int, complex128) string) *Value {
+	groups := make(map[string][]complex128)
+	v.EachComplex128(func(index int, val complex128) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]complex128, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceComplex128 uses the specified function to replace each complex128s
+// by iterating each item.  The data in the returned result will be a
+// []complex128 containing the replaced items.
+func (v *Value) ReplaceComplex128(replacer func(int, complex128) complex128) *Value {
+	arr := v.MustComplex128Slice()
+	replaced := make([]complex128, len(arr))
+	v.EachComplex128(func(index int, val complex128) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectComplex128 uses the specified collector function to collect a value
+// for each of the complex128s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectComplex128(collector func(int, complex128) interface{}) *Value {
+	arr := v.MustComplex128Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachComplex128(func(index int, val complex128) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}

--- a/vendor/github.com/stretchr/objx/value.go
+++ b/vendor/github.com/stretchr/objx/value.go
@@ -1,0 +1,53 @@
+package objx
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Value provides methods for extracting interface{} data in various
+// types.
+type Value struct {
+	// data contains the raw data being managed by this Value
+	data interface{}
+}
+
+// Data returns the raw data contained by this Value
+func (v *Value) Data() interface{} {
+	return v.data
+}
+
+// String returns the value always as a string
+func (v *Value) String() string {
+	switch {
+	case v.IsStr():
+		return v.Str()
+	case v.IsBool():
+		return strconv.FormatBool(v.Bool())
+	case v.IsFloat32():
+		return strconv.FormatFloat(float64(v.Float32()), 'f', -1, 32)
+	case v.IsFloat64():
+		return strconv.FormatFloat(v.Float64(), 'f', -1, 64)
+	case v.IsInt():
+		return strconv.FormatInt(int64(v.Int()), 10)
+	case v.IsInt8():
+		return strconv.FormatInt(int64(v.Int8()), 10)
+	case v.IsInt16():
+		return strconv.FormatInt(int64(v.Int16()), 10)
+	case v.IsInt32():
+		return strconv.FormatInt(int64(v.Int32()), 10)
+	case v.IsInt64():
+		return strconv.FormatInt(v.Int64(), 10)
+	case v.IsUint():
+		return strconv.FormatUint(uint64(v.Uint()), 10)
+	case v.IsUint8():
+		return strconv.FormatUint(uint64(v.Uint8()), 10)
+	case v.IsUint16():
+		return strconv.FormatUint(uint64(v.Uint16()), 10)
+	case v.IsUint32():
+		return strconv.FormatUint(uint64(v.Uint32()), 10)
+	case v.IsUint64():
+		return strconv.FormatUint(v.Uint64(), 10)
+	}
+	return fmt.Sprintf("%#v", v.Data())
+}

--- a/vendor/github.com/stretchr/testify/mock/doc.go
+++ b/vendor/github.com/stretchr/testify/mock/doc.go
@@ -1,0 +1,44 @@
+// Package mock provides a system by which it is possible to mock your objects
+// and verify calls are happening as expected.
+//
+// Example Usage
+//
+// The mock package provides an object, Mock, that tracks activity on another object.  It is usually
+// embedded into a test object as shown below:
+//
+//   type MyTestObject struct {
+//     // add a Mock object instance
+//     mock.Mock
+//
+//     // other fields go here as normal
+//   }
+//
+// When implementing the methods of an interface, you wire your functions up
+// to call the Mock.Called(args...) method, and return the appropriate values.
+//
+// For example, to mock a method that saves the name and age of a person and returns
+// the year of their birth or an error, you might write this:
+//
+//     func (o *MyTestObject) SavePersonDetails(firstname, lastname string, age int) (int, error) {
+//       args := o.Called(firstname, lastname, age)
+//       return args.Int(0), args.Error(1)
+//     }
+//
+// The Int, Error and Bool methods are examples of strongly typed getters that take the argument
+// index position. Given this argument list:
+//
+//     (12, true, "Something")
+//
+// You could read them out strongly typed like this:
+//
+//     args.Int(0)
+//     args.Bool(1)
+//     args.String(2)
+//
+// For objects of your own type, use the generic Arguments.Get(index) method and make a type assertion:
+//
+//     return args.Get(0).(*MyObject), args.Get(1).(*AnotherObjectOfMine)
+//
+// This may cause a panic if the object you are getting is nil (the type assertion will fail), in those
+// cases you should check for nil first.
+package mock

--- a/vendor/github.com/stretchr/testify/mock/mock.go
+++ b/vendor/github.com/stretchr/testify/mock/mock.go
@@ -1,0 +1,885 @@
+package mock
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/objx"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Logf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+/*
+	Call
+*/
+
+// Call represents a method call and is used for setting expectations,
+// as well as recording activity.
+type Call struct {
+	Parent *Mock
+
+	// The name of the method that was or will be called.
+	Method string
+
+	// Holds the arguments of the method.
+	Arguments Arguments
+
+	// Holds the arguments that should be returned when
+	// this method is called.
+	ReturnArguments Arguments
+
+	// Holds the caller info for the On() call
+	callerInfo []string
+
+	// The number of times to return the return arguments when setting
+	// expectations. 0 means to always return the value.
+	Repeatability int
+
+	// Amount of times this call has been called
+	totalCalls int
+
+	// Call to this method can be optional
+	optional bool
+
+	// Holds a channel that will be used to block the Return until it either
+	// receives a message or is closed. nil means it returns immediately.
+	WaitFor <-chan time.Time
+
+	waitTime time.Duration
+
+	// Holds a handler used to manipulate arguments content that are passed by
+	// reference. It's useful when mocking methods such as unmarshalers or
+	// decoders.
+	RunFn func(Arguments)
+}
+
+func newCall(parent *Mock, methodName string, callerInfo []string, methodArguments ...interface{}) *Call {
+	return &Call{
+		Parent:          parent,
+		Method:          methodName,
+		Arguments:       methodArguments,
+		ReturnArguments: make([]interface{}, 0),
+		callerInfo:      callerInfo,
+		Repeatability:   0,
+		WaitFor:         nil,
+		RunFn:           nil,
+	}
+}
+
+func (c *Call) lock() {
+	c.Parent.mutex.Lock()
+}
+
+func (c *Call) unlock() {
+	c.Parent.mutex.Unlock()
+}
+
+// Return specifies the return arguments for the expectation.
+//
+//    Mock.On("DoSomething").Return(errors.New("failed"))
+func (c *Call) Return(returnArguments ...interface{}) *Call {
+	c.lock()
+	defer c.unlock()
+
+	c.ReturnArguments = returnArguments
+
+	return c
+}
+
+// Once indicates that that the mock should only return the value once.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Once()
+func (c *Call) Once() *Call {
+	return c.Times(1)
+}
+
+// Twice indicates that that the mock should only return the value twice.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Twice()
+func (c *Call) Twice() *Call {
+	return c.Times(2)
+}
+
+// Times indicates that that the mock should only return the indicated number
+// of times.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Times(5)
+func (c *Call) Times(i int) *Call {
+	c.lock()
+	defer c.unlock()
+	c.Repeatability = i
+	return c
+}
+
+// WaitUntil sets the channel that will block the mock's return until its closed
+// or a message is received.
+//
+//    Mock.On("MyMethod", arg1, arg2).WaitUntil(time.After(time.Second))
+func (c *Call) WaitUntil(w <-chan time.Time) *Call {
+	c.lock()
+	defer c.unlock()
+	c.WaitFor = w
+	return c
+}
+
+// After sets how long to block until the call returns
+//
+//    Mock.On("MyMethod", arg1, arg2).After(time.Second)
+func (c *Call) After(d time.Duration) *Call {
+	c.lock()
+	defer c.unlock()
+	c.waitTime = d
+	return c
+}
+
+// Run sets a handler to be called before returning. It can be used when
+// mocking a method such as unmarshalers that takes a pointer to a struct and
+// sets properties in such struct
+//
+//    Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}").Return().Run(func(args Arguments) {
+//    	arg := args.Get(0).(*map[string]interface{})
+//    	arg["foo"] = "bar"
+//    })
+func (c *Call) Run(fn func(args Arguments)) *Call {
+	c.lock()
+	defer c.unlock()
+	c.RunFn = fn
+	return c
+}
+
+// Maybe allows the method call to be optional. Not calling an optional method
+// will not cause an error while asserting expectations
+func (c *Call) Maybe() *Call {
+	c.lock()
+	defer c.unlock()
+	c.optional = true
+	return c
+}
+
+// On chains a new expectation description onto the mocked interface. This
+// allows syntax like.
+//
+//    Mock.
+//       On("MyMethod", 1).Return(nil).
+//       On("MyOtherMethod", 'a', 'b', 'c').Return(errors.New("Some Error"))
+func (c *Call) On(methodName string, arguments ...interface{}) *Call {
+	return c.Parent.On(methodName, arguments...)
+}
+
+// Mock is the workhorse used to track activity on another object.
+// For an example of its usage, refer to the "Example Usage" section at the top
+// of this document.
+type Mock struct {
+	// Represents the calls that are expected of
+	// an object.
+	ExpectedCalls []*Call
+
+	// Holds the calls that were made to this mocked object.
+	Calls []Call
+
+	// test is An optional variable that holds the test struct, to be used when an
+	// invalid mock call was made.
+	test TestingT
+
+	// TestData holds any data that might be useful for testing.  Testify ignores
+	// this data completely allowing you to do whatever you like with it.
+	testData objx.Map
+
+	mutex sync.Mutex
+}
+
+// TestData holds any data that might be useful for testing.  Testify ignores
+// this data completely allowing you to do whatever you like with it.
+func (m *Mock) TestData() objx.Map {
+
+	if m.testData == nil {
+		m.testData = make(objx.Map)
+	}
+
+	return m.testData
+}
+
+/*
+	Setting expectations
+*/
+
+// Test sets the test struct variable of the mock object
+func (m *Mock) Test(t TestingT) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.test = t
+}
+
+// fail fails the current test with the given formatted format and args.
+// In case that a test was defined, it uses the test APIs for failing a test,
+// otherwise it uses panic.
+func (m *Mock) fail(format string, args ...interface{}) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.test == nil {
+		panic(fmt.Sprintf(format, args...))
+	}
+	m.test.Errorf(format, args...)
+	m.test.FailNow()
+}
+
+// On starts a description of an expectation of the specified method
+// being called.
+//
+//     Mock.On("MyMethod", arg1, arg2)
+func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
+	for _, arg := range arguments {
+		if v := reflect.ValueOf(arg); v.Kind() == reflect.Func {
+			panic(fmt.Sprintf("cannot use Func in expectations. Use mock.AnythingOfType(\"%T\")", arg))
+		}
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	c := newCall(m, methodName, assert.CallerInfo(), arguments...)
+	m.ExpectedCalls = append(m.ExpectedCalls, c)
+	return c
+}
+
+// /*
+// 	Recording and responding to activity
+// */
+
+func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
+	for i, call := range m.ExpectedCalls {
+		if call.Method == method && call.Repeatability > -1 {
+
+			_, diffCount := call.Arguments.Diff(arguments)
+			if diffCount == 0 {
+				return i, call
+			}
+
+		}
+	}
+	return -1, nil
+}
+
+func (m *Mock) findClosestCall(method string, arguments ...interface{}) (*Call, string) {
+	var diffCount int
+	var closestCall *Call
+	var err string
+
+	for _, call := range m.expectedCalls() {
+		if call.Method == method {
+
+			errInfo, tempDiffCount := call.Arguments.Diff(arguments)
+			if tempDiffCount < diffCount || diffCount == 0 {
+				diffCount = tempDiffCount
+				closestCall = call
+				err = errInfo
+			}
+
+		}
+	}
+
+	return closestCall, err
+}
+
+func callString(method string, arguments Arguments, includeArgumentValues bool) string {
+
+	var argValsString string
+	if includeArgumentValues {
+		var argVals []string
+		for argIndex, arg := range arguments {
+			argVals = append(argVals, fmt.Sprintf("%d: %#v", argIndex, arg))
+		}
+		argValsString = fmt.Sprintf("\n\t\t%s", strings.Join(argVals, "\n\t\t"))
+	}
+
+	return fmt.Sprintf("%s(%s)%s", method, arguments.String(), argValsString)
+}
+
+// Called tells the mock object that a method has been called, and gets an array
+// of arguments to return.  Panics if the call is unexpected (i.e. not preceded by
+// appropriate .On .Return() calls)
+// If Call.WaitFor is set, blocks until the channel is closed or receives a message.
+func (m *Mock) Called(arguments ...interface{}) Arguments {
+	// get the calling function's name
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("Couldn't get the caller information")
+	}
+	functionPath := runtime.FuncForPC(pc).Name()
+	//Next four lines are required to use GCCGO function naming conventions.
+	//For Ex:  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock
+	//uses interface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
+	//With GCCGO we need to remove interface information starting from pN<dd>.
+	re := regexp.MustCompile("\\.pN\\d+_")
+	if re.MatchString(functionPath) {
+		functionPath = re.Split(functionPath, -1)[0]
+	}
+	parts := strings.Split(functionPath, ".")
+	functionName := parts[len(parts)-1]
+	return m.MethodCalled(functionName, arguments...)
+}
+
+// MethodCalled tells the mock object that the given method has been called, and gets
+// an array of arguments to return. Panics if the call is unexpected (i.e. not preceded
+// by appropriate .On .Return() calls)
+// If Call.WaitFor is set, blocks until the channel is closed or receives a message.
+func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Arguments {
+	m.mutex.Lock()
+	//TODO: could combine expected and closes in single loop
+	found, call := m.findExpectedCall(methodName, arguments...)
+
+	if found < 0 {
+		// we have to fail here - because we don't know what to do
+		// as the return arguments.  This is because:
+		//
+		//   a) this is a totally unexpected call to this method,
+		//   b) the arguments are not what was expected, or
+		//   c) the developer has forgotten to add an accompanying On...Return pair.
+
+		closestCall, mismatch := m.findClosestCall(methodName, arguments...)
+		m.mutex.Unlock()
+
+		if closestCall != nil {
+			m.fail("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n\n%s\nDiff: %s",
+				callString(methodName, arguments, true),
+				callString(methodName, closestCall.Arguments, true),
+				diffArguments(closestCall.Arguments, arguments),
+				strings.TrimSpace(mismatch),
+			)
+		} else {
+			m.fail("\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s", methodName, methodName, callString(methodName, arguments, true), assert.CallerInfo())
+		}
+	}
+
+	if call.Repeatability == 1 {
+		call.Repeatability = -1
+	} else if call.Repeatability > 1 {
+		call.Repeatability--
+	}
+	call.totalCalls++
+
+	// add the call
+	m.Calls = append(m.Calls, *newCall(m, methodName, assert.CallerInfo(), arguments...))
+	m.mutex.Unlock()
+
+	// block if specified
+	if call.WaitFor != nil {
+		<-call.WaitFor
+	} else {
+		time.Sleep(call.waitTime)
+	}
+
+	m.mutex.Lock()
+	runFn := call.RunFn
+	m.mutex.Unlock()
+
+	if runFn != nil {
+		runFn(arguments)
+	}
+
+	m.mutex.Lock()
+	returnArgs := call.ReturnArguments
+	m.mutex.Unlock()
+
+	return returnArgs
+}
+
+/*
+	Assertions
+*/
+
+type assertExpectationser interface {
+	AssertExpectations(TestingT) bool
+}
+
+// AssertExpectationsForObjects asserts that everything specified with On and Return
+// of the specified objects was in fact called as expected.
+//
+// Calls may have occurred in any order.
+func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	for _, obj := range testObjects {
+		if m, ok := obj.(Mock); ok {
+			t.Logf("Deprecated mock.AssertExpectationsForObjects(myMock.Mock) use mock.AssertExpectationsForObjects(myMock)")
+			obj = &m
+		}
+		m := obj.(assertExpectationser)
+		if !m.AssertExpectations(t) {
+			t.Logf("Expectations didn't match for Mock: %+v", reflect.TypeOf(m))
+			return false
+		}
+	}
+	return true
+}
+
+// AssertExpectations asserts that everything specified with On and Return was
+// in fact called as expected.  Calls may have occurred in any order.
+func (m *Mock) AssertExpectations(t TestingT) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var somethingMissing bool
+	var failedExpectations int
+
+	// iterate through each expectation
+	expectedCalls := m.expectedCalls()
+	for _, expectedCall := range expectedCalls {
+		if !expectedCall.optional && !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments) && expectedCall.totalCalls == 0 {
+			somethingMissing = true
+			failedExpectations++
+			t.Logf("FAIL:\t%s(%s)\n\t\tat: %s", expectedCall.Method, expectedCall.Arguments.String(), expectedCall.callerInfo)
+		} else {
+			if expectedCall.Repeatability > 0 {
+				somethingMissing = true
+				failedExpectations++
+				t.Logf("FAIL:\t%s(%s)\n\t\tat: %s", expectedCall.Method, expectedCall.Arguments.String(), expectedCall.callerInfo)
+			} else {
+				t.Logf("PASS:\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
+			}
+		}
+	}
+
+	if somethingMissing {
+		t.Errorf("FAIL: %d out of %d expectation(s) were met.\n\tThe code you are testing needs to make %d more call(s).\n\tat: %s", len(expectedCalls)-failedExpectations, len(expectedCalls), failedExpectations, assert.CallerInfo())
+	}
+
+	return !somethingMissing
+}
+
+// AssertNumberOfCalls asserts that the method was called expectedCalls times.
+func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls int) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var actualCalls int
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+			actualCalls++
+		}
+	}
+	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
+}
+
+// AssertCalled asserts that the method was called.
+// It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
+func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if !m.methodWasCalled(methodName, arguments) {
+		var calledWithArgs []string
+		for _, call := range m.calls() {
+			calledWithArgs = append(calledWithArgs, fmt.Sprintf("%v", call.Arguments))
+		}
+		if len(calledWithArgs) == 0 {
+			return assert.Fail(t, "Should have called with given arguments",
+				fmt.Sprintf("Expected %q to have been called with:\n%v\nbut no actual calls happened", methodName, arguments))
+		}
+		return assert.Fail(t, "Should have called with given arguments",
+			fmt.Sprintf("Expected %q to have been called with:\n%v\nbut actual calls were:\n        %v", methodName, arguments, strings.Join(calledWithArgs, "\n")))
+	}
+	return true
+}
+
+// AssertNotCalled asserts that the method was not called.
+// It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
+func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.methodWasCalled(methodName, arguments) {
+		return assert.Fail(t, "Should not have called with given arguments",
+			fmt.Sprintf("Expected %q to not have been called with:\n%v\nbut actually it was.", methodName, arguments))
+	}
+	return true
+}
+
+func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+
+			_, differences := Arguments(expected).Diff(call.Arguments)
+
+			if differences == 0 {
+				// found the expected call
+				return true
+			}
+
+		}
+	}
+	// we didn't find the expected call
+	return false
+}
+
+func (m *Mock) expectedCalls() []*Call {
+	return append([]*Call{}, m.ExpectedCalls...)
+}
+
+func (m *Mock) calls() []Call {
+	return append([]Call{}, m.Calls...)
+}
+
+/*
+	Arguments
+*/
+
+// Arguments holds an array of method arguments or return values.
+type Arguments []interface{}
+
+const (
+	// Anything is used in Diff and Assert when the argument being tested
+	// shouldn't be taken into consideration.
+	Anything = "mock.Anything"
+)
+
+// AnythingOfTypeArgument is a string that contains the type of an argument
+// for use when type checking.  Used in Diff and Assert.
+type AnythingOfTypeArgument string
+
+// AnythingOfType returns an AnythingOfTypeArgument object containing the
+// name of the type to check for.  Used in Diff and Assert.
+//
+// For example:
+//	Assert(t, AnythingOfType("string"), AnythingOfType("int"))
+func AnythingOfType(t string) AnythingOfTypeArgument {
+	return AnythingOfTypeArgument(t)
+}
+
+// argumentMatcher performs custom argument matching, returning whether or
+// not the argument is matched by the expectation fixture function.
+type argumentMatcher struct {
+	// fn is a function which accepts one argument, and returns a bool.
+	fn reflect.Value
+}
+
+func (f argumentMatcher) Matches(argument interface{}) bool {
+	expectType := f.fn.Type().In(0)
+	expectTypeNilSupported := false
+	switch expectType.Kind() {
+	case reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Ptr:
+		expectTypeNilSupported = true
+	}
+
+	argType := reflect.TypeOf(argument)
+	var arg reflect.Value
+	if argType == nil {
+		arg = reflect.New(expectType).Elem()
+	} else {
+		arg = reflect.ValueOf(argument)
+	}
+
+	if argType == nil && !expectTypeNilSupported {
+		panic(errors.New("attempting to call matcher with nil for non-nil expected type"))
+	}
+	if argType == nil || argType.AssignableTo(expectType) {
+		result := f.fn.Call([]reflect.Value{arg})
+		return result[0].Bool()
+	}
+	return false
+}
+
+func (f argumentMatcher) String() string {
+	return fmt.Sprintf("func(%s) bool", f.fn.Type().In(0).Name())
+}
+
+// MatchedBy can be used to match a mock call based on only certain properties
+// from a complex struct or some calculation. It takes a function that will be
+// evaluated with the called argument and will return true when there's a match
+// and false otherwise.
+//
+// Example:
+// m.On("Do", MatchedBy(func(req *http.Request) bool { return req.Host == "example.com" }))
+//
+// |fn|, must be a function accepting a single argument (of the expected type)
+// which returns a bool. If |fn| doesn't match the required signature,
+// MatchedBy() panics.
+func MatchedBy(fn interface{}) argumentMatcher {
+	fnType := reflect.TypeOf(fn)
+
+	if fnType.Kind() != reflect.Func {
+		panic(fmt.Sprintf("assert: arguments: %s is not a func", fn))
+	}
+	if fnType.NumIn() != 1 {
+		panic(fmt.Sprintf("assert: arguments: %s does not take exactly one argument", fn))
+	}
+	if fnType.NumOut() != 1 || fnType.Out(0).Kind() != reflect.Bool {
+		panic(fmt.Sprintf("assert: arguments: %s does not return a bool", fn))
+	}
+
+	return argumentMatcher{fn: reflect.ValueOf(fn)}
+}
+
+// Get Returns the argument at the specified index.
+func (args Arguments) Get(index int) interface{} {
+	if index+1 > len(args) {
+		panic(fmt.Sprintf("assert: arguments: Cannot call Get(%d) because there are %d argument(s).", index, len(args)))
+	}
+	return args[index]
+}
+
+// Is gets whether the objects match the arguments specified.
+func (args Arguments) Is(objects ...interface{}) bool {
+	for i, obj := range args {
+		if obj != objects[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Diff gets a string describing the differences between the arguments
+// and the specified objects.
+//
+// Returns the diff string and number of differences found.
+func (args Arguments) Diff(objects []interface{}) (string, int) {
+	//TODO: could return string as error and nil for No difference
+
+	var output = "\n"
+	var differences int
+
+	var maxArgCount = len(args)
+	if len(objects) > maxArgCount {
+		maxArgCount = len(objects)
+	}
+
+	for i := 0; i < maxArgCount; i++ {
+		var actual, expected interface{}
+		var actualFmt, expectedFmt string
+
+		if len(objects) <= i {
+			actual = "(Missing)"
+			actualFmt = "(Missing)"
+		} else {
+			actual = objects[i]
+			actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
+		}
+
+		if len(args) <= i {
+			expected = "(Missing)"
+			expectedFmt = "(Missing)"
+		} else {
+			expected = args[i]
+			expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
+		}
+
+		if matcher, ok := expected.(argumentMatcher); ok {
+			if matcher.Matches(actual) {
+				output = fmt.Sprintf("%s\t%d: PASS:  %s matched by %s\n", output, i, actualFmt, matcher)
+			} else {
+				differences++
+				output = fmt.Sprintf("%s\t%d: PASS:  %s not matched by %s\n", output, i, actualFmt, matcher)
+			}
+		} else if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
+
+			// type checking
+			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
+				// not match
+				differences++
+				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+			}
+
+		} else {
+
+			// normal checking
+
+			if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
+				// match
+				output = fmt.Sprintf("%s\t%d: PASS:  %s == %s\n", output, i, actualFmt, expectedFmt)
+			} else {
+				// not match
+				differences++
+				output = fmt.Sprintf("%s\t%d: FAIL:  %s != %s\n", output, i, actualFmt, expectedFmt)
+			}
+		}
+
+	}
+
+	if differences == 0 {
+		return "No differences.", differences
+	}
+
+	return output, differences
+
+}
+
+// Assert compares the arguments with the specified objects and fails if
+// they do not exactly match.
+func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	// get the differences
+	diff, diffCount := args.Diff(objects)
+
+	if diffCount == 0 {
+		return true
+	}
+
+	// there are differences... report them...
+	t.Logf(diff)
+	t.Errorf("%sArguments do not match.", assert.CallerInfo())
+
+	return false
+
+}
+
+// String gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+//
+// If no index is provided, String() returns a complete string representation
+// of the arguments.
+func (args Arguments) String(indexOrNil ...int) string {
+
+	if len(indexOrNil) == 0 {
+		// normal String() method - return a string representation of the args
+		var argsStr []string
+		for _, arg := range args {
+			argsStr = append(argsStr, fmt.Sprintf("%s", reflect.TypeOf(arg)))
+		}
+		return strings.Join(argsStr, ",")
+	} else if len(indexOrNil) == 1 {
+		// Index has been specified - get the argument at that index
+		var index = indexOrNil[0]
+		var s string
+		var ok bool
+		if s, ok = args.Get(index).(string); !ok {
+			panic(fmt.Sprintf("assert: arguments: String(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+		}
+		return s
+	}
+
+	panic(fmt.Sprintf("assert: arguments: Wrong number of arguments passed to String.  Must be 0 or 1, not %d", len(indexOrNil)))
+
+}
+
+// Int gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int(index int) int {
+	var s int
+	var ok bool
+	if s, ok = args.Get(index).(int); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
+	}
+	return s
+}
+
+// Error gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Error(index int) error {
+	obj := args.Get(index)
+	var s error
+	var ok bool
+	if obj == nil {
+		return nil
+	}
+	if s, ok = obj.(error); !ok {
+		panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
+	}
+	return s
+}
+
+// Bool gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Bool(index int) bool {
+	var s bool
+	var ok bool
+	if s, ok = args.Get(index).(bool); !ok {
+		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
+	}
+	return s
+}
+
+func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+	t := reflect.TypeOf(v)
+	k := t.Kind()
+
+	if k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
+	}
+	return t, k
+}
+
+func diffArguments(expected Arguments, actual Arguments) string {
+	if len(expected) != len(actual) {
+		return fmt.Sprintf("Provided %v arguments, mocked for %v arguments", len(expected), len(actual))
+	}
+
+	for x := range expected {
+		if diffString := diff(expected[x], actual[x]); diffString != "" {
+			return fmt.Sprintf("Difference found in argument %v:\n\n%s", x, diffString)
+		}
+	}
+
+	return ""
+}
+
+// diff returns a diff of both values as long as both are of the same type and
+// are a struct, map, slice or array. Otherwise it returns an empty string.
+func diff(expected interface{}, actual interface{}) string {
+	if expected == nil || actual == nil {
+		return ""
+	}
+
+	et, ek := typeAndKind(expected)
+	at, _ := typeAndKind(actual)
+
+	if et != at {
+		return ""
+	}
+
+	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array {
+		return ""
+	}
+
+	e := spewConfig.Sdump(expected)
+	a := spewConfig.Sdump(actual)
+
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(e),
+		B:        difflib.SplitLines(a),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	return diff
+}
+
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+}
+
+type tHelper interface {
+	Helper()
+}


### PR DESCRIPTION
- add `Poster` interface (posts analysis results)
- add `LogPoster` for playing around
- add `github.Poster` using GitHub Code Review API
- rework all the APIs a bit, specially git package so that everything fits together
- add `serve` subcommand to the `lookout` binary with full server working (currently using LogPoster)
- add basic auth to the GitHub client
- make `lookout serve` use `github.Poster` (disable with `--dry-run`)
