### PR TITLE
Refactor server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ $(PROTOC):
 test-sdk: clean-sdk build-sdk
 	$(DUMMY_BIN) serve &>/dev/null & \
 	PID=$$!; \
-	$(LOOKOUT_BIN) review ipv4://localhost:10302 | grep "BEGIN RESULT"; \
+	$(LOOKOUT_BIN) review ipv4://localhost:10302 2>&1 | grep "posting analysis"; \
 	if [ $$? != 0 ] ; then \
 		echo "review test failed"; \
 		kill $$PID; \

--- a/cmd/lookout/push.go
+++ b/cmd/lookout/push.go
@@ -29,18 +29,16 @@ func (c *PushCommand) Execute(args []string) error {
 		return err
 	}
 
-	grpcSrv, err := c.makeDataServer()
-	if err != nil {
-		return err
-	}
-
-	lis, err := lookout.Listen(c.DataServer)
+	dataSrv, err := c.makeDataServerHandler()
 	if err != nil {
 		return err
 	}
 
 	serveResult := make(chan error)
-	go func() { serveResult <- grpcSrv.Serve(lis) }()
+	grpcSrv, err := c.bindDataServer(dataSrv, serveResult)
+	if err != nil {
+		return err
+	}
 
 	client, err := c.analyzerClient()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ func (s *Server) handleEvent(ctx context.Context, e Event) error {
 	}
 }
 
+// HandlePR sends request to analyzers concurrently
 func (s *Server) HandlePR(ctx context.Context, e *ReviewEvent) error {
 	logger := log.DefaultLogger.With(log.Fields{
 		"provider":   e.Provider,

--- a/server.go
+++ b/server.go
@@ -31,14 +31,14 @@ func (s *Server) Run(ctx context.Context) error {
 func (s *Server) handleEvent(ctx context.Context, e Event) error {
 	switch ev := e.(type) {
 	case *ReviewEvent:
-		return s.handlePR(ctx, ev)
+		return s.HandlePR(ctx, ev)
 	default:
 		log.Debugf("ignoring unsupported event: %s", ev)
 		return nil
 	}
 }
 
-func (s *Server) handlePR(ctx context.Context, e *ReviewEvent) error {
+func (s *Server) HandlePR(ctx context.Context, e *ReviewEvent) error {
 	logger := log.DefaultLogger.With(log.Fields{
 		"provider":   e.Provider,
 		"repository": e.Head.InternalRepositoryURL,

--- a/server.go
+++ b/server.go
@@ -1,0 +1,110 @@
+package lookout
+
+import (
+	"context"
+	"sync"
+
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// Server implements glue between providers / data-server / analyzers
+type Server struct {
+	watcher    Watcher
+	poster     Poster
+	fileGetter FileGetter
+	analyzers  map[string]AnalyzerClient
+}
+
+// NewServer creates new Server
+func NewServer(w Watcher, p Poster, fileGetter FileGetter, analyzers map[string]AnalyzerClient) *Server {
+	return &Server{w, p, fileGetter, analyzers}
+}
+
+// Run starts server
+func (s *Server) Run(ctx context.Context) error {
+	// FIXME(max): we most probably want to change interface of EventHandler instead of it
+	return s.watcher.Watch(ctx, func(e Event) error {
+		return s.handleEvent(ctx, e)
+	})
+}
+
+func (s *Server) handleEvent(ctx context.Context, e Event) error {
+	switch ev := e.(type) {
+	case *ReviewEvent:
+		return s.handlePR(ctx, ev)
+	default:
+		log.Debugf("ignoring unsupported event: %s", ev)
+		return nil
+	}
+}
+
+func (s *Server) handlePR(ctx context.Context, e *ReviewEvent) error {
+	logger := log.DefaultLogger.With(log.Fields{
+		"provider":   e.Provider,
+		"repository": e.Head.InternalRepositoryURL,
+		"head":       e.Head.ReferenceName,
+	})
+	logger.Infof("processing pull request")
+
+	var comments commentsList
+
+	var wg sync.WaitGroup
+	for name, a := range s.analyzers {
+		wg.Add(1)
+		go func(name string, a AnalyzerClient) {
+			defer wg.Done()
+
+			aLogger := logger.With(log.Fields{
+				"analyzer": name,
+			})
+
+			resp, err := a.NotifyReviewEvent(context.TODO(), e)
+			if err != nil {
+				aLogger.Errorf(err, "analysis failed")
+				return
+			}
+
+			if len(resp.Comments) == 0 {
+				aLogger.Infof("no comments were produced")
+			}
+
+			comments.Add(resp.Comments...)
+		}(name, a)
+	}
+	wg.Wait()
+
+	if !comments.Empty() {
+		logger.With(log.Fields{
+			"comments": comments.Len(),
+		}).Infof("posting analysis")
+
+		if err := s.poster.Post(ctx, e, comments.Get()); err != nil {
+			logger.Errorf(err, "posting analysis failed")
+		}
+	}
+
+	return nil
+}
+
+type commentsList struct {
+	sync.Mutex
+	list []*Comment
+}
+
+func (l *commentsList) Add(cs ...*Comment) {
+	l.Lock()
+	l.list = append(l.list, cs...)
+	l.Unlock()
+}
+
+func (l *commentsList) Get() []*Comment {
+	return l.list
+}
+
+func (l *commentsList) Len() int {
+	return len(l.list)
+}
+
+func (l *commentsList) Empty() bool {
+	return len(l.list) == 0
+}


### PR DESCRIPTION
Needed for https://github.com/src-d/lookout/issues/20

Free perk:
```
$ ./build/bin/lookout review ipv4://localhost:10302
[2018-07-20T17:20:13.860020105+02:00]  INFO processing pull request app=lookout head=HEAD provider= repository=file:///Users/smacker/go/src/github.com/src-d/lookout
[2018-07-20T17:20:14.748419032+02:00]  INFO posting analysis app=lookout comments=20 head=HEAD provider= repository=file:///Users/smacker/go/src/github.com/src-d/lookout
[2018-07-20T17:20:14.748493289+02:00]  INFO file comment app=lookout file=cmd/lookout/event.go text=The file has increased in 12 lines.
[2018-07-20T17:20:14.748526231+02:00]  INFO line comment app=lookout file=cmd/lookout/event.go line=20 text=This line exceeded 80 bytes.
....
```

The main idea we need new class `Server` because we need to communicate with data-server.
Though I’m open to any other suggestions that will connect analyzes sender&fileGetter.
