### PR TITLE
Add version

### DIFF
--- a/cmd/lookout/main.go
+++ b/cmd/lookout/main.go
@@ -11,11 +11,17 @@ import (
 
 const maxMsgSize = 1024 * 1024 * 100 // 100mb
 
-func init() {
-	log.DefaultLogger = log.New(log.Fields{"app": "lookout"})
-}
+var (
+	name    = "lookout"
+	version = "undefined"
+	build   = "undefined"
+)
 
 var parser = flags.NewParser(nil, flags.Default)
+
+func init() {
+	log.DefaultLogger = log.New(log.Fields{"app": name})
+}
 
 func main() {
 	if _, err := parser.Parse(); err != nil {

--- a/cmd/lookout/version.go
+++ b/cmd/lookout/version.go
@@ -1,0 +1,30 @@
+package main
+
+import "fmt"
+
+// VersionCommand represents the `version` command of lookout CLI.
+type VersionCommand struct {
+	// Name of the binary
+	Name string
+	// Version of the binary
+	Version string
+	// Build of the binary
+	Build string
+}
+
+func init() {
+	if _, err := parser.AddCommand("version", "show version information", "",
+		&VersionCommand{
+			Name:    name,
+			Version: version,
+			Build:   build,
+		}); err != nil {
+		panic(err)
+	}
+}
+
+// Execute prints the build information provided at the compilation time.
+func (v *VersionCommand) Execute(args []string) error {
+	fmt.Printf("%s %s built on %s\n", v.Name, v.Version, v.Build)
+	return nil
+}


### PR DESCRIPTION
Adds `lookout version` i.e

```
$ lookout version
lookout dev-c784875-dirty built on 07-24-2018_12_05_04
```