### PR TITLE
Console provider

### DIFF
--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -94,11 +94,18 @@ func (c *ServeCommand) initPoster() (lookout.Poster, error) {
 		return &LogPoster{log.DefaultLogger}, nil
 	}
 
-	return github.NewPoster(&roundTripper{
-		Log:      log.DefaultLogger,
-		User:     c.GithubUser,
-		Password: c.GithubToken,
-	}), nil
+	switch c.Provider {
+	case github.Provider:
+		return github.NewPoster(&roundTripper{
+			Log:      log.DefaultLogger,
+			User:     c.GithubUser,
+			Password: c.GithubToken,
+		}), nil
+	case console.Provider:
+		return console.NewPoster(os.Stdout), nil
+	default:
+		return nil, fmt.Errorf("provider %s not supported", c.Provider)
+	}
 }
 
 func (c *ServeCommand) initWatcher() (lookout.Watcher, error) {

--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/provider/console"
 	"github.com/src-d/lookout/provider/github"
 	"github.com/src-d/lookout/service/bblfsh"
 	"github.com/src-d/lookout/service/git"
@@ -32,6 +34,7 @@ type ServeCommand struct {
 	Bblfshd     string `long:"bblfshd" default:"ipv4://localhost:9432" env:"LOOKOUT_BBLFSHD" description:"gRPC URL of the Bblfshd server"`
 	DryRun      bool   `long:"dry-run" env:"LOOKOUT_DRY_RUN" description:"analyze repositories and log the result without posting code reviews to GitHub"`
 	Library     string `long:"library" default:"/tmp/lookout" env:"LOOKOUT_LIBRARY" description:"path to the lookout library"`
+	Provider    string `long:"provider" default:"github" env:"LOOKOUT_PROVIDER" description:"provider name: github, console"`
 	Positional  struct {
 		Repository string `positional-arg-name:"repository"`
 	} `positional-args:"yes" required:"yes"`
@@ -77,14 +80,7 @@ func (c *ServeCommand) Execute(args []string) error {
 		return err
 	}
 
-	t := &roundTripper{
-		Log:      log.DefaultLogger,
-		User:     c.GithubUser,
-		Password: c.GithubToken,
-	}
-	watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
-		URL: c.Positional.Repository,
-	})
+	watcher, err := c.initWatcher()
 	if err != nil {
 		return err
 	}
@@ -103,6 +99,32 @@ func (c *ServeCommand) initPoster() (lookout.Poster, error) {
 		User:     c.GithubUser,
 		Password: c.GithubToken,
 	}), nil
+}
+
+func (c *ServeCommand) initWatcher() (lookout.Watcher, error) {
+	switch c.Provider {
+	case github.Provider:
+		t := &roundTripper{
+			Log:      log.DefaultLogger,
+			User:     c.GithubUser,
+			Password: c.GithubToken,
+		}
+
+		watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
+			URL: c.Positional.Repository,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return watcher, nil
+	case console.Provider:
+		return console.NewWatcher(&console.WatchOptions{
+			Reader: os.Stdin,
+		})
+	default:
+		return nil, fmt.Errorf("provider %s not supported", c.Provider)
+	}
 }
 
 func (c *ServeCommand) startAnalyzer(conf lookout.AnalyzerConfig) (lookout.AnalyzerClient, error) {

--- a/provider/console/poster.go
+++ b/provider/console/poster.go
@@ -1,0 +1,49 @@
+package console
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/src-d/lookout"
+)
+
+// Poster prints comments to stdout
+type Poster struct {
+	writer io.Writer
+}
+
+var _ lookout.Poster = &Poster{}
+
+// NewPoster creates a new poster for stdout
+func NewPoster(w io.Writer) *Poster {
+	return &Poster{
+		writer: w,
+	}
+}
+
+var (
+	globalComment = "%s\n"
+	fileComment   = "%s: %s\n"
+	lineComment   = "%s:%d: %s\n"
+)
+
+// Post prints comments to sdtout
+func (p *Poster) Post(ctx context.Context, e lookout.Event,
+	comments []*lookout.Comment) error {
+
+	for _, c := range comments {
+		if c.File == "" {
+			fmt.Fprintf(p.writer, globalComment, c.Text)
+			continue
+		}
+		if c.Line == 0 {
+			fmt.Fprintf(p.writer, fileComment, c.File, c.Text)
+			continue
+		}
+
+		fmt.Fprintf(p.writer, lineComment, c.File, c.Line, c.Text)
+	}
+
+	return nil
+}

--- a/provider/console/poster_test.go
+++ b/provider/console/poster_test.go
@@ -1,0 +1,63 @@
+package console
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/src-d/lookout"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+var (
+	hash1 = "f67e5455a86d0f2a366f1b980489fac77a373bd0"
+	hash2 = "02801e1a27a0a906d59530aeb81f4cd137f2c717"
+	base1 = plumbing.ReferenceName("base")
+	head1 = plumbing.ReferenceName("refs/pull/42/head")
+)
+
+func TestPoster_Post_OK(t *testing.T) {
+	require := require.New(t)
+
+	var b bytes.Buffer
+
+	p := NewPoster(&b)
+	ev := &lookout.ReviewEvent{
+		Provider: Provider,
+		CommitRevision: lookout.CommitRevision{
+			Base: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+				ReferenceName:         base1,
+				Hash:                  hash1,
+			},
+			Head: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+				ReferenceName:         head1,
+				Hash:                  hash2,
+			}}}
+	cs := []*lookout.Comment{&lookout.Comment{
+		Text: "This is a global comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Text: "This is a file comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Line: 5,
+		Text: "This is a line comment",
+	}, &lookout.Comment{
+		Text: "This is a another global comment",
+	}}
+
+	err := p.Post(context.Background(), ev, cs)
+	require.NoError(err)
+
+	expected := fmt.Sprintf(globalComment, cs[0].Text) +
+		fmt.Sprintf(fileComment, cs[1].File, cs[1].Text) +
+		fmt.Sprintf(lineComment, cs[2].File, cs[2].Line, cs[2].Text) +
+		fmt.Sprintf(globalComment, cs[3].Text)
+
+	require.Equal(expected, b.String())
+}

--- a/provider/console/watcher.go
+++ b/provider/console/watcher.go
@@ -1,0 +1,126 @@
+package console
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/src-d/lookout"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// Provider is the name
+const Provider = "console"
+
+// WatchOptions options to use in the Watcher constructor.
+type WatchOptions struct {
+	Reader io.Reader
+}
+
+// Watcher watches for new events in the console
+type Watcher struct {
+	o       *WatchOptions
+	scanner *bufio.Scanner
+}
+
+// NewWatcher returns a new console watcher
+func NewWatcher(o *WatchOptions) (*Watcher, error) {
+	return &Watcher{
+		o:       o,
+		scanner: bufio.NewScanner(o.Reader),
+	}, nil
+}
+
+// Watch reads from stdin and calls cb for each new event
+func (w *Watcher) Watch(ctx context.Context, cb lookout.EventHandler) error {
+	log.With(log.Fields{"provider": Provider}).Infof("Starting watcher")
+
+	lines := make(chan string, 1)
+	go func() {
+		for w.scanner.Scan() {
+			lines <- w.scanner.Text()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case line := <-lines:
+			if err := w.handleInput(cb, line); err != nil {
+				if lookout.NoErrStopWatcher.Is(err) {
+					return nil
+				}
+
+				return err
+			}
+		}
+	}
+}
+
+func (w *Watcher) handleInput(cb lookout.EventHandler, line string) error {
+	if line == "" {
+		return nil
+	}
+
+	var cmd, gitURL, fromBranch, fromHash, toBranch, toHash string
+	_, err := fmt.Sscanf(line,
+		"%s %s %s %s %s %s",
+		&cmd, &gitURL, &fromBranch, &fromHash, &toBranch, &toHash)
+
+	if err != nil {
+		log.Errorf(err, "could not process input line %q", line)
+		return nil
+	}
+
+	var event lookout.Event
+
+	commitRev := lookout.CommitRevision{
+		Base: lookout.ReferencePointer{
+			InternalRepositoryURL: gitURL,
+			ReferenceName:         plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", fromBranch)),
+			Hash:                  fromHash,
+		},
+		Head: lookout.ReferencePointer{
+			InternalRepositoryURL: gitURL,
+			ReferenceName:         plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", toBranch)),
+			Hash:                  toHash,
+		},
+	}
+
+	switch strings.ToLower(cmd) {
+	case "review":
+		event = &lookout.ReviewEvent{
+			Provider:    Provider,
+			InternalID:  "1",
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+			IsMergeable: true,
+			//Source
+			//Merge
+			//Configuration
+			CommitRevision: commitRev,
+		}
+
+	case "push":
+		event = &lookout.PushEvent{
+			Provider:   Provider,
+			InternalID: "1",
+			CreatedAt:  time.Now(),
+			//Commits
+			//DistinctCommits
+			//Configuration
+			CommitRevision: commitRev,
+		}
+	default:
+		log.Errorf(nil, "event %q not supported", cmd)
+		return nil
+	}
+
+	return cb(event)
+}

--- a/provider/console/watcher_test.go
+++ b/provider/console/watcher_test.go
@@ -1,0 +1,97 @@
+package console
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/pb"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type WatcherTestSuite struct {
+	suite.Suite
+}
+
+func (s *WatcherTestSuite) SetupTest() {
+
+}
+
+var pushStr = "PUSH http://github.com/foo/bar master hash1 my-branch hash2"
+var badStr = "NOPE foo bar"
+
+func (s *WatcherTestSuite) TestWatch() {
+	var events int
+
+	w, err := NewWatcher(&WatchOptions{
+		Reader: strings.NewReader(pushStr),
+	})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		events++
+
+		s.Equal(pb.PushEventType, e.Type())
+		s.Equal("http://github.com/foo/bar", e.Revision().Base.InternalRepositoryURL)
+		return nil
+	})
+
+	s.Equal(1, events)
+	s.Error(err, "context deadline exceeded")
+}
+
+func (s *WatcherTestSuite) TestWatch_WrongEvent() {
+	var events int
+
+	w, err := NewWatcher(&WatchOptions{
+		Reader: strings.NewReader(badStr),
+	})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		events++
+		return nil
+	})
+
+	s.Equal(0, events)
+	s.Error(err, "context deadline exceeded")
+}
+
+func (s *WatcherTestSuite) TestWatch_WithError() {
+	w, err := NewWatcher(&WatchOptions{
+		Reader: strings.NewReader(pushStr),
+	})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		s.Equal(pb.PushEventType, e.Type())
+		s.Equal("http://github.com/foo/bar", e.Revision().Base.InternalRepositoryURL)
+		return fmt.Errorf("foo")
+	})
+
+	s.Error(err)
+	s.Equal("foo", err.Error())
+}
+
+func (s *WatcherTestSuite) TearDownSuite() {
+}
+
+func TestWatcherTestSuite(t *testing.T) {
+	suite.Run(t, new(WatcherTestSuite))
+}


### PR DESCRIPTION
Part of #40.

This PR adds a new console provider, watcher and poster. It will listen for events in sdtin and output the comments to stdout.

It can be run as:

```bash
go run cmd/lookout/* serve  --provider console repourl
```

The events have to be provided as a line with the format
```
REVIEW/PUSH repoURL baseBranch baseHash headBranch headHash
```
For example:
```
review https://github.com/carlosms/lookout.git master 0ac15b52f3ea4e3f22f347904547c3651dc26f5e console-provider 5ed66cc9ebcc62bed0c58e9b376f4d9baf2122ed
```
```
review file:///home/cmartin/go/src/github.com/src-d/lookout master 0ac15b52f3ea4e3f22f347904547c3651dc26f5e console-provider 5ed66cc9ebcc62bed0c58e9b376f4d9baf2122ed
```

The comments from the dummy analyzer look like this:
```
cmd/lookout/serve.go: The file has increased in 29 lines.
cmd/lookout/serve.go:30: This line exceeded 80 bytes.
cmd/lookout/serve.go:31: This line exceeded 80 bytes.
```

A few notes:

- `lookout serve` requires the positional argument of a repo url, that the new provider ignores. I left it as it is because eventually we'll manage the repos we monitor in a different way (conf file or DB).
- The usage is not as clean as with `lookout review`, where you can just give two nice revision names and it would work, because:
  - We don't know if the repo is a local dir, so here we can't use go-git to get the hash of a revision.
  - `serve` uses `LibraryCommitLoader`, whereas `review` uses `StorerCommitLoader`. For this reason we need to provide both the reference name and the hash.
- Right now you can't trigger an analysis with base and head from two different repositories, so you can't compare a fork with its base repo. This is enforced in the data server side, [loader.go#L43](https://github.com/src-d/lookout/blob/master/service/git/loader.go#L43)