### PR TITLE
Add json provider watcher & poster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,17 @@ jobs:
       osx_image: xcode9.4
       before_install: skip
     - script:
+      - cp config.yml.tpl config.yml
+      - make test-json
+      name: "Lookout serve Integration Tests Linux"
+    - script:
+      - cp config.yml.tpl config.yml
+      - make test-json
+      name: "Lookout serve Integration Tests macOS"
+      os: osx
+      osx_image: xcode9.4
+      before_install: skip
+    - script:
         - make protogen
         - make no-changes-in-commit
         # check that proto files are buildable by python

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,31 @@ test-sdk: clean-sdk build-sdk
 	fi; \
 	kill $$PID || true ; \
 
+# Integration test for lookout serve
+.PHONY: test-json
+test-json: build-sdk
+	$(DUMMY_BIN) serve &>/dev/null & \
+	DUMMY_PID=$$!; \
+	cat fixtures/events.jsonl | $(LOOKOUT_BIN) serve --provider json dummy-repo-url > serve.txt 2> serve-err.txt & \
+	LOOKOUT_PID=$$!; \
+	for i in `seq 0 120`; do \
+		sleep 1; \
+		grep '{"file":"provider/common.go","text":"The file has increased in 5 lines."}' serve.txt; \
+		if [ $$? = 0 ] ; then \
+			kill $$LOOKOUT_PID; \
+			kill $$DUMMY_PID; \
+			exit 0; \
+		fi; \
+	done; \
+	echo "timeout reached, inspect serve.txt and serve-err.txt for details"; \
+	echo -e "\nserve.txt:"; \
+	cat serve.txt; \
+	echo -e "\nserve-err.txt:"; \
+	cat serve-err.txt; \
+	kill $$LOOKOUT_PID; \
+	kill $$DUMMY_PID; \
+	exit 1; \
+
 # Build sdk client and dummy analyzer
 .PHONY: build-sdk
 build-sdk: $(DUMMY_BIN) $(LOOKOUT_BIN)

--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/provider/github"
+	"github.com/src-d/lookout/provider/json"
 	"github.com/src-d/lookout/service/bblfsh"
 	"github.com/src-d/lookout/service/git"
 	"github.com/src-d/lookout/util/flags"
@@ -35,6 +37,7 @@ type ServeCommand struct {
 	Bblfshd     string `long:"bblfshd" default:"ipv4://localhost:9432" env:"LOOKOUT_BBLFSHD" description:"gRPC URL of the Bblfshd server"`
 	DryRun      bool   `long:"dry-run" env:"LOOKOUT_DRY_RUN" description:"analyze repositories and log the result without posting code reviews to GitHub"`
 	Library     string `long:"library" default:"/tmp/lookout" env:"LOOKOUT_LIBRARY" description:"path to the lookout library"`
+	Provider    string `long:"provider" default:"github" env:"LOOKOUT_PROVIDER" description:"provider name: github, console"`
 	Positional  struct {
 		Repository string `positional-arg-name:"repository"`
 	} `positional-args:"yes" required:"yes"`
@@ -80,14 +83,7 @@ func (c *ServeCommand) Execute(args []string) error {
 		return err
 	}
 
-	t := &roundTripper{
-		Log:      log.DefaultLogger,
-		User:     c.GithubUser,
-		Password: c.GithubToken,
-	}
-	watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
-		URL: c.Positional.Repository,
-	})
+	watcher, err := c.initWatcher()
 	if err != nil {
 		return err
 	}
@@ -101,11 +97,42 @@ func (c *ServeCommand) initPoster() (lookout.Poster, error) {
 		return &LogPoster{log.DefaultLogger}, nil
 	}
 
-	return github.NewPoster(&roundTripper{
-		Log:      log.DefaultLogger,
-		User:     c.GithubUser,
-		Password: c.GithubToken,
-	}), nil
+	switch c.Provider {
+	case github.Provider:
+		return github.NewPoster(&roundTripper{
+			Log:      log.DefaultLogger,
+			User:     c.GithubUser,
+			Password: c.GithubToken,
+		}), nil
+	case json.Provider:
+		return json.NewPoster(os.Stdout), nil
+	default:
+		return nil, fmt.Errorf("provider %s not supported", c.Provider)
+	}
+}
+
+func (c *ServeCommand) initWatcher() (lookout.Watcher, error) {
+	switch c.Provider {
+	case github.Provider:
+		t := &roundTripper{
+			Log:      log.DefaultLogger,
+			User:     c.GithubUser,
+			Password: c.GithubToken,
+		}
+
+		watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
+			URL: c.Positional.Repository,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return watcher, nil
+	case json.Provider:
+		return json.NewWatcher(os.Stdin, &lookout.WatchOptions{})
+	default:
+		return nil, fmt.Errorf("provider %s not supported", c.Provider)
+	}
 }
 
 func (c *ServeCommand) startAnalyzer(conf lookout.AnalyzerConfig) (lookout.AnalyzerClient, error) {

--- a/event.go
+++ b/event.go
@@ -14,6 +14,8 @@ type Event interface {
 	// Revision returns a commit revision, containing the head and the base of
 	// the changes.
 	Revision() *CommitRevision
+	// Validate returns an error if the event is malformed
+	Validate() error
 }
 
 type EventID = pb.EventID

--- a/fixtures/events.jsonl
+++ b/fixtures/events.jsonl
@@ -1,0 +1,1 @@
+{"event":"review", "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","ReferenceName":"refs/heads/master","Hash":"4eebef102d7979570aadf69ff54ae1ffcca7ce00"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","ReferenceName":"refs/heads/master","Hash":"d304499cb2a9cad3ea260f06ad59c1658db4763d"}}}

--- a/pb/event.go
+++ b/pb/event.go
@@ -3,7 +3,9 @@ package pb
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"reflect"
 
 	"gopkg.in/sourcegraph/go-vcsurl.v1"
 )
@@ -53,6 +55,16 @@ func (e *ReviewEvent) Revision() *CommitRevision {
 	return &e.CommitRevision
 }
 
+// Validate honors the Event interface.
+func (e *ReviewEvent) Validate() error {
+	var zeroVal ReviewEvent
+	if reflect.DeepEqual(*e, zeroVal) {
+		return errors.New("this ReviewEvent event is empty")
+	}
+
+	return nil
+}
+
 // ID honors the Event interface.
 func (e *PushEvent) ID() EventID {
 	return ComputeEventID(e.Provider, e.InternalID)
@@ -66,6 +78,16 @@ func (e *PushEvent) Type() EventType {
 // Revision honors the Event interface.
 func (e *PushEvent) Revision() *CommitRevision {
 	return &e.CommitRevision
+}
+
+// Validate honors the Event interface.
+func (e *PushEvent) Validate() error {
+	var zeroVal PushEvent
+	if reflect.DeepEqual(*e, zeroVal) {
+		return errors.New("this PushEvent event is empty")
+	}
+
+	return nil
 }
 
 type RepositoryInfo = vcsurl.RepoInfo //TODO(mcuadros): improve repository references

--- a/provider/json/poster.go
+++ b/provider/json/poster.go
@@ -1,0 +1,38 @@
+package json
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/src-d/lookout"
+)
+
+// Poster prints json comments to stdout
+type Poster struct {
+	writer io.Writer
+	enc    *json.Encoder
+}
+
+var _ lookout.Poster = &Poster{}
+
+// NewPoster creates a new json poster for stdout
+func NewPoster(w io.Writer) *Poster {
+	return &Poster{
+		writer: w,
+		enc:    json.NewEncoder(w),
+	}
+}
+
+// Post prints json comments to sdtout
+func (p *Poster) Post(ctx context.Context, e lookout.Event,
+	comments []*lookout.Comment) error {
+
+	for _, c := range comments {
+		if err := p.enc.Encode(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/provider/json/poster_test.go
+++ b/provider/json/poster_test.go
@@ -1,0 +1,63 @@
+package json
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/src-d/lookout"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+var (
+	hash1 = "f67e5455a86d0f2a366f1b980489fac77a373bd0"
+	hash2 = "02801e1a27a0a906d59530aeb81f4cd137f2c717"
+	base1 = plumbing.ReferenceName("base")
+	head1 = plumbing.ReferenceName("refs/pull/42/head")
+)
+
+func TestPoster_Post_OK(t *testing.T) {
+	require := require.New(t)
+
+	var b bytes.Buffer
+
+	p := NewPoster(&b)
+	ev := &lookout.ReviewEvent{
+		Provider: Provider,
+		CommitRevision: lookout.CommitRevision{
+			Base: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+				ReferenceName:         base1,
+				Hash:                  hash1,
+			},
+			Head: lookout.ReferencePointer{
+				InternalRepositoryURL: "https://github.com/foo/bar",
+				ReferenceName:         head1,
+				Hash:                  hash2,
+			}}}
+	cs := []*lookout.Comment{&lookout.Comment{
+		Text: "This is a global comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Text: "This is a file comment",
+	}, &lookout.Comment{
+		File: "main.go",
+		Line: 5,
+		Text: "This is a line comment",
+	}, &lookout.Comment{
+		Text: "This is a another global comment",
+	}}
+
+	err := p.Post(context.Background(), ev, cs)
+	require.NoError(err)
+
+	expected := `{"text":"This is a global comment"}
+{"file":"main.go","text":"This is a file comment"}
+{"file":"main.go","line":5,"text":"This is a line comment"}
+{"text":"This is a another global comment"}
+`
+
+	require.Equal(expected, b.String())
+}

--- a/provider/json/watcher.go
+++ b/provider/json/watcher.go
@@ -1,0 +1,104 @@
+package json
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/src-d/lookout"
+
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// Provider is the name
+const Provider = "json"
+
+// Watcher watches for new json events in the console
+type Watcher struct {
+	o       *lookout.WatchOptions
+	scanner *bufio.Scanner
+}
+
+// NewWatcher returns a new json console watcher
+func NewWatcher(reader io.Reader, o *lookout.WatchOptions) (*Watcher, error) {
+	return &Watcher{
+		o:       o,
+		scanner: bufio.NewScanner(reader),
+	}, nil
+}
+
+// Watch reads json from stdin and calls cb for each new event
+func (w *Watcher) Watch(ctx context.Context, cb lookout.EventHandler) error {
+	log.With(log.Fields{"provider": Provider}).Infof("Starting watcher")
+
+	lines := make(chan string, 1)
+	go func() {
+		for w.scanner.Scan() {
+			lines <- w.scanner.Text()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case line := <-lines:
+			if err := w.handleInput(cb, line); err != nil {
+				if lookout.NoErrStopWatcher.Is(err) {
+					return nil
+				}
+
+				return err
+			}
+		}
+	}
+}
+
+type eventType struct {
+	Event string `json:"event"`
+}
+
+func (w *Watcher) handleInput(cb lookout.EventHandler, line string) error {
+	if line == "" {
+		return nil
+	}
+
+	var eventType eventType
+
+	if err := json.Unmarshal([]byte(line), &eventType); err != nil {
+		log.With(log.Fields{"input": line}).Errorf(err, "could not unmarshal the event")
+
+		return nil
+	}
+
+	var event lookout.Event
+
+	switch strings.ToLower(eventType.Event) {
+	case "":
+		log.With(log.Fields{"input": line}).Errorf(nil, `field "event" is mandatory`)
+		return nil
+	case "review":
+		var reviewEvent *lookout.ReviewEvent
+		if err := json.Unmarshal([]byte(line), &reviewEvent); err != nil {
+			log.With(log.Fields{"input": line}).Errorf(err, "could not unmarshal the ReviewEvent")
+			return nil
+		}
+
+		event = reviewEvent
+	case "push":
+		var pushEvent *lookout.PushEvent
+		if err := json.Unmarshal([]byte(line), &pushEvent); err != nil {
+			log.With(log.Fields{"input": line}).Errorf(err, "could not unmarshal the PushEvent")
+			return nil
+		}
+
+		event = pushEvent
+	default:
+		log.Errorf(nil, "event %q not supported", eventType.Event)
+		return nil
+	}
+
+	return cb(event)
+}

--- a/provider/json/watcher_test.go
+++ b/provider/json/watcher_test.go
@@ -1,0 +1,116 @@
+package json
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/pb"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type WatcherTestSuite struct {
+	suite.Suite
+}
+
+func (s *WatcherTestSuite) SetupTest() {
+
+}
+
+var (
+	pushJSON   = `{"event":"push", "commit_revision":{"base":{"internal_repository_url":"http://github.com/foo/bar","ReferenceName":"refs/heads/master","Hash":"hash1"},"head":{"internal_repository_url":"http://github.com/foo/bar","ReferenceName":"refs/heads/my-branch","Hash":"hash2"}}}`
+	reviewJSON = `{"event":"review", "commit_revision":{"base":{"internal_repository_url":"http://github.com/foo/bar","ReferenceName":"refs/heads/master","Hash":"hash1"},"head":{"internal_repository_url":"http://github.com/foo/bar","ReferenceName":"refs/heads/my-branch","Hash":"hash2"}}}`
+	badEvent   = `{"event":"none"}`
+	badJSON    = `{"event":"push", { ...`
+)
+
+func (s *WatcherTestSuite) TestWatch() {
+	var events int
+
+	w, err := NewWatcher(strings.NewReader(pushJSON+"\n"+reviewJSON), &lookout.WatchOptions{})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	expectedTypes := []pb.EventType{pb.PushEventType, pb.ReviewEventType}
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		s.Equal(expectedTypes[events], e.Type())
+		s.Equal("http://github.com/foo/bar", e.Revision().Base.InternalRepositoryURL)
+
+		events++
+		return nil
+	})
+
+	s.Equal(2, events)
+	s.Error(err, "context deadline exceeded")
+}
+
+func (s *WatcherTestSuite) TestWatch_WrongEvent() {
+	var events int
+
+	w, err := NewWatcher(strings.NewReader(badEvent), &lookout.WatchOptions{})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		events++
+		return nil
+	})
+
+	s.Equal(0, events)
+	s.Error(err, "context deadline exceeded")
+}
+
+func (s *WatcherTestSuite) TestWatch_BadJSON() {
+	var events int
+
+	w, err := NewWatcher(strings.NewReader(badEvent), &lookout.WatchOptions{})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		events++
+		return nil
+	})
+
+	s.Equal(0, events)
+	s.Error(err, "context deadline exceeded")
+}
+
+func (s *WatcherTestSuite) TestWatch_WithError() {
+	w, err := NewWatcher(strings.NewReader(pushJSON), &lookout.WatchOptions{})
+
+	s.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	err = w.Watch(ctx, func(e lookout.Event) error {
+		s.Equal(pb.PushEventType, e.Type())
+		s.Equal("http://github.com/foo/bar", e.Revision().Base.InternalRepositoryURL)
+		return fmt.Errorf("foo")
+	})
+
+	s.Error(err)
+	s.Equal("foo", err.Error())
+}
+
+func (s *WatcherTestSuite) TearDownSuite() {
+}
+
+func TestWatcherTestSuite(t *testing.T) {
+	suite.Run(t, new(WatcherTestSuite))
+}

--- a/server.go
+++ b/server.go
@@ -75,6 +75,11 @@ func (s *Server) HandleReview(ctx context.Context, e *ReviewEvent) error {
 	})
 	logger.Infof("processing pull request")
 
+	if err := e.Validate(); err != nil {
+		logger.Errorf(err, "processing pull request failed")
+		return nil
+	}
+
 	conf, err := s.getConfig(ctx, logger, e)
 	if err != nil {
 		return err
@@ -105,6 +110,11 @@ func (s *Server) HandlePush(ctx context.Context, e *PushEvent) error {
 		"head":       e.Head.ReferenceName,
 	})
 	logger.Infof("processing push")
+
+	if err := e.Validate(); err != nil {
+		logger.Errorf(err, "processing push failed")
+		return nil
+	}
 
 	conf, err := s.getConfig(ctx, logger, e)
 	if err != nil {


### PR DESCRIPTION
Fixes #40.

As discussed via chat, we are discarding the previous console provider (#57) in favor of this json stdio provider.

It can be run as:

```bash
go run cmd/lookout/* serve  --provider json repourl
```

The events have to be provided as one line json with the same format as protobuf events (reference for [ReviewEvent](https://github.com/src-d/lookout/blob/master/pb/event.pb.go#L103)), plus a field: `"event" :  "review/push"`.

For example, having this content in `events.jsonl`:
```json
{"event":"review", "commit_revision":{"base":{"internal_repository_url":"https://github.com/carlosms/lookout.git","ReferenceName":"refs/heads/master","Hash":"0ac15b52f3ea4e3f22f347904547c3651dc26f5e"},"head":{"internal_repository_url":"https://github.com/carlosms/lookout.git","ReferenceName":"refs/heads/console-provider","Hash":"5ed66cc9ebcc62bed0c58e9b376f4d9baf2122ed"}}}
```

You can run 
```
cat events.jsonl | go run cmd/lookout/* serve  --provider json repourl
{"file":"cmd/lookout/serve.go","text":"The file has increased in 29 lines."}
{"file":"cmd/lookout/serve.go","line":30,"text":"This line exceeded 80 bytes."}
{"file":"cmd/lookout/serve.go","line":31,"text":"This line exceeded 80 bytes."}
{"file":"cmd/lookout/serve.go","line":32,"text":"This line exceeded 80 bytes."}
...
```

A few comments:
- `lookout serve` requires the positional argument of a repo url, that the new provider ignores. I left it as it is because eventually we'll manage the repos we monitor in a different way (conf file or DB).
- When redirecting the stdout (`> out.txt 2> err.txt`) the logs go correctly to stderr, except for gRPC ones. But I think this will be part of #47 and should not be fixed in this PR.
- Here is the previous input json formatted, for convenience. These are the minimum json fields that need to be provided for the dummy analyzer to work.
```json
{
   "commit_revision" : {
      "head" : {
         "Hash" : "5ed66cc9ebcc62bed0c58e9b376f4d9baf2122ed",
         "internal_repository_url" : "https://github.com/carlosms/lookout.git",
         "ReferenceName" : "refs/heads/console-provider"
      },
      "base" : {
         "Hash" : "0ac15b52f3ea4e3f22f347904547c3651dc26f5e",
         "internal_repository_url" : "https://github.com/carlosms/lookout.git",
         "ReferenceName" : "refs/heads/master"
      }
   },
   "event" : "review"
}
```