### PR TITLE
Watch multiple GitHub repos

### DIFF
--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/provider/github"
@@ -119,7 +120,7 @@ func (c *ServeCommand) initWatcher() (lookout.Watcher, error) {
 		}
 
 		watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
-			URL: c.Positional.Repository,
+			URLs: strings.Split(c.Positional.Repository, ","),
 		})
 		if err != nil {
 			return nil, err

--- a/watcher.go
+++ b/watcher.go
@@ -25,5 +25,5 @@ type EventHandler func(Event) error
 
 // WatchOptions options to use in the Watcher constructors.
 type WatchOptions struct {
-	URL string
+	URLs []string
 }


### PR DESCRIPTION
Fix #41.

The changes are basic: repos are provided as a comma separated list. The watcher then does a round robin to poll each repo.

The way I understand [the docs](https://developer.github.com/v3/activity/events/), even if we poll for a different repo, we need to wait the `X-Poll-Interval` since the interval in enforced for the github user.