### PR TITLE
Report GitHub status

### DIFF
--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -221,6 +221,12 @@ func (p *LogPoster) Post(ctx context.Context, e lookout.Event,
 	return nil
 }
 
+func (p *LogPoster) Status(ctx context.Context, e lookout.Event,
+	status lookout.AnalysisStatus) error {
+	p.Log.Infof("status: %s", status)
+	return nil
+}
+
 type roundTripper struct {
 	Log      log.Logger
 	Base     http.RoundTripper

--- a/poster.go
+++ b/poster.go
@@ -2,8 +2,36 @@ package lookout
 
 import "context"
 
+// AnalysisStatus is the status reported to the provider to
+// inform that we are performing an analysis, or that it has finished
+type AnalysisStatus int
+
+const (
+	_ AnalysisStatus = iota
+	// ErrorAnalysisStatus represents an error status
+	ErrorAnalysisStatus
+	// FailureAnalysisStatus represents a failure status
+	FailureAnalysisStatus
+	// PendingAnalysisStatus represents a pending status
+	PendingAnalysisStatus
+	// SuccessAnalysisStatus represents a success status
+	SuccessAnalysisStatus
+)
+
+func (st AnalysisStatus) String() string {
+	names := [...]string{"unknown", "error", "failure", "pending", "success"}
+	if st < ErrorAnalysisStatus || st > SuccessAnalysisStatus {
+		return names[0]
+	}
+
+	return names[st]
+}
+
 // Poster can post comments about an event.
 type Poster interface {
 	// Post posts comments about an event.
 	Post(context.Context, Event, []*Comment) error
+
+	// Status sends the current analysis status to the provider
+	Status(context.Context, Event, AnalysisStatus) error
 }

--- a/provider/json/poster.go
+++ b/provider/json/poster.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/src-d/lookout"
+	"gopkg.in/src-d/go-log.v1"
 )
 
 // Poster prints json comments to stdout
@@ -34,5 +35,13 @@ func (p *Poster) Post(ctx context.Context, e lookout.Event,
 		}
 	}
 
+	return nil
+}
+
+// Status prints the new status to the log
+func (p *Poster) Status(ctx context.Context, e lookout.Event,
+	status lookout.AnalysisStatus) error {
+
+	log.With(log.Fields{"status": status}).Infof("New status")
 	return nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -56,6 +56,9 @@ func TestServerReview(t *testing.T) {
 	comments := poster.PopComments()
 	require.Len(comments, 1)
 	require.Equal(makeComment(reviewEvent.CommitRevision.Base, reviewEvent.CommitRevision.Head), comments[0])
+
+	status := poster.PopStatus()
+	require.Equal(SuccessAnalysisStatus, status)
 }
 
 func TestServerPush(t *testing.T) {
@@ -86,6 +89,9 @@ func TestServerPush(t *testing.T) {
 	comments := poster.PopComments()
 	require.Len(comments, 1)
 	require.Equal(makeComment(pushEvent.CommitRevision.Base, pushEvent.CommitRevision.Head), comments[0])
+
+	status := poster.PopStatus()
+	require.Equal(SuccessAnalysisStatus, status)
 }
 
 func TestAnalyzerConfigDisabled(t *testing.T) {
@@ -111,6 +117,9 @@ func TestAnalyzerConfigDisabled(t *testing.T) {
 
 	comments := poster.PopComments()
 	require.Len(comments, 0)
+
+	status := poster.PopStatus()
+	require.Equal(SuccessAnalysisStatus, status)
 }
 
 var globalConfig = AnalyzerConfig{
@@ -266,6 +275,7 @@ func (w *WatcherMock) Send(e Event) error {
 
 type PosterMock struct {
 	comments []*Comment
+	status   AnalysisStatus
 }
 
 func (p *PosterMock) Post(_ context.Context, e Event, cs []*Comment) error {
@@ -277,6 +287,17 @@ func (p *PosterMock) PopComments() []*Comment {
 	cs := p.comments[:]
 	p.comments = []*Comment{}
 	return cs
+}
+
+func (p *PosterMock) Status(_ context.Context, e Event, st AnalysisStatus) error {
+	p.status = st
+	return nil
+}
+
+func (p *PosterMock) PopStatus() AnalysisStatus {
+	st := p.status
+	p.status = 0
+	return st
 }
 
 type FileGetterMock struct {


### PR DESCRIPTION
Fixes #42.

Using the [status API](https://developer.github.com/v3/repos/statuses/) the server sets the status to _pending_, and then _success_ when the comment posting finishes.

The states follow the GitHub names since for now it's our reference provider. But I think they are flexible enough to fit into new providers. For example for [GitLab pilelines](https://docs.gitlab.com/ee/api/pipelines.html) we have:

| GitHub | Gitlab |
| -- | -- |
| error | canceled |
| failure | failed |
| pending | pending |
| success | success | 