### PR TITLE
vendor scaner panic without file

### DIFF
--- a/service/git/scanner.go
+++ b/service/git/scanner.go
@@ -296,6 +296,10 @@ func NewChangeBlobScanner(scanner lookout.ChangeScanner, base, head *object.Tree
 }
 
 func filterVendor(f *lookout.File) (bool, error) {
+	if f == nil {
+		return false, nil
+	}
+
 	return enry.IsVendor(f.Path), nil
 }
 

--- a/service/git/service_test.go
+++ b/service/git/service_test.go
@@ -61,6 +61,32 @@ func (s *ServiceSuite) TestTreeChanges() {
 	require.NotNil(resp)
 }
 
+func (s *ServiceSuite) TestTreeChangesDeleteFile() {
+	require := s.Require()
+
+	fixture := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
+	fs := fixture.DotGit()
+	sto, err := filesystem.NewStorage(fs)
+	require.NoError(err)
+
+	dr := NewService(&StorerCommitLoader{sto})
+	resp, err := dr.GetChanges(context.TODO(), &lookout.ChangesRequest{
+		Base: &lookout.ReferencePointer{
+			InternalRepositoryURL: "file:///myrepo",
+			Hash: "2275fa7d0c75d20103f90b0e1616937d5a9fc5e6",
+		},
+		Head: &lookout.ReferencePointer{
+			InternalRepositoryURL: "file:///myrepo",
+			Hash: "e1d8866ffa78fa16d2f39b0ba5344a7269ee5371",
+		},
+		WantContents:    true,
+		ExcludeVendored: true,
+	})
+
+	require.NoError(err)
+	require.NotNil(resp)
+}
+
 func (s *ServiceSuite) TestTreeFiles() {
 	require := s.Require()
 


### PR DESCRIPTION
Fix: #91

I added test only for `git service`, not the scanner itself.