### PR TITLE
Uast tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ jobs:
       name: "Unit Tests"
       script: make test-coverage codecov
     - script:
-        - docker run -d --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
+        - docker run -d --name bblfshd --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
+        - docker exec -it bblfshd bblfshctl driver install go bblfsh/go-driver:v2.0.3
         - make test-sdk
       name: "SDK Integration Tests Linux"
     - script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,6 @@ jobs:
         - docker run -d --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
         - make test-sdk
       name: "SDK Integration Tests Linux"
-    - script: 
-        - docker run -d --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
-        - make test-sdk
-      name: "SDK Integration Tests macOS"
-      os: osx
-      osx_image: xcode9.4
-      before_install: skip
     - script:
       - cp config.yml.tpl config.yml
       - make test-json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+sudo: required
+services:
+  - docker
+
 addons:
   apt:
     sources:
@@ -25,9 +29,13 @@ jobs:
     - stage: tests
       name: "Unit Tests"
       script: make test-coverage codecov
-    - script: make test-sdk
+    - script:
+        - docker run -d --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
+        - make test-sdk
       name: "SDK Integration Tests Linux"
-    - script: make test-sdk
+    - script: 
+        - docker run -d --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
+        - make test-sdk
       name: "SDK Integration Tests macOS"
       os: osx
       osx_image: xcode9.4
@@ -72,7 +80,12 @@ jobs:
       script: PKG_OS="darwin" make packages-sdk
       deploy: *deploy_anchor
 
+before_cache:
+  # make bblfsh images readable
+  - sudo chmod -R 777 $HOME/bblfshd/images
+
 cache:
   directories:
     - $HOME/protoc
     - $HOME/.cache/pip/wheels
+    - $HOME/bblfshd/images

--- a/Makefile
+++ b/Makefile
@@ -56,21 +56,7 @@ $(PROTOC):
 # Integration test for sdk client
 .PHONY: test-sdk
 test-sdk: clean-sdk build-sdk
-	$(DUMMY_BIN) serve &>/dev/null & \
-	PID=$$!; \
-	$(LOOKOUT_BIN) review ipv4://localhost:10302 2>&1 | grep "posting analysis"; \
-	if [ $$? != 0 ] ; then \
-		echo "review test failed"; \
-		kill $$PID; \
-		exit 1; \
-	fi; \
-	$(LOOKOUT_BIN) push ipv4://localhost:10302 2>&1 | grep "dummy comment for push event"; \
-	if [ $$? != 0 ] ; then \
-		echo "push test failed"; \
-		kill $$PID; \
-		exit 1; \
-	fi; \
-	kill $$PID || true ; \
+	DUMMY_BIN=$(DUMMY_BIN) LOOKOUT_BIN=$(LOOKOUT_BIN) $(GOCMD) run sdk-test/main.go
 
 # Integration test for lookout serve
 .PHONY: test-json

--- a/sdk-test/main.go
+++ b/sdk-test/main.go
@@ -33,12 +33,12 @@ func main() {
 
 	fmt.Print("testing review...")
 	out := runCli(ctx, "review", "ipv4://localhost:10302")
-	grepFailedExit(out.String(), "posting analysis")
+	grepFailedExit(out.String(), "posting analysis", 1)
 	fmt.Println("OK!")
 
 	fmt.Print("testing push...")
 	out = runCli(ctx, "push", "ipv4://localhost:10302")
-	grepFailedExit(out.String(), "dummy comment for push event")
+	grepFailedExit(out.String(), "dummy comment for push event", 1)
 	fmt.Println("OK!")
 
 	// next tests require analyzier started with UAST, restart analyzer
@@ -49,14 +49,14 @@ func main() {
 
 	fmt.Print("should return error without bblfsh...")
 	out = runCli(ctx, "review", "ipv4://localhost:10302", "--bblfshd=ipv4://localhost:0000")
-	grepFailedExit(out.String(), "WantUAST isn't allowed")
+	grepFailedExit(out.String(), "WantUAST isn't allowed", 1)
 	fmt.Println("OK!")
 
 	fmt.Print("should notify about lack of uast...")
 	out = runCli(ctx, "review", "ipv4://localhost:10302",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	grepFailedExit(out.String(), "The file doesn't have UAST")
+	grepFailedExit(out.String(), "The file doesn't have UAST", 1)
 	fmt.Println("OK!")
 
 	stop()
@@ -120,8 +120,8 @@ func handleErr(err error, desc string, out bytes.Buffer) {
 	failExit()
 }
 
-func grepFailedExit(content, msg string) {
-	if !strings.Contains(content, msg) {
+func grepFailedExit(content, msg string, times int) {
+	if strings.Count(content, msg) != times {
 		fmt.Printf("'%s' not found in:\n%s", msg, content)
 		fmt.Printf("analyzer output\n %s", analyzerOut.String())
 		failExit()

--- a/sdk-test/main.go
+++ b/sdk-test/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// changes might be huge and it will take time to process them
+var timeout = time.Minute
+
+// default path to binaries
+var dummyBin = "build/bin/dummy"
+var lookoutBin = "build/bin/lookout"
+
+// we need to stop analyzer that runs in background
+var stop func()
+
+var analyzerOut bytes.Buffer
+
+func main() {
+	readEnv()
+
+	fmt.Println("start integration testing")
+	ctx, timeoutCancel := context.WithTimeout(context.Background(), timeout)
+	defer timeoutCancel()
+
+	startDummy(ctx)
+
+	fmt.Print("testing review...")
+	out := runCli(ctx, "review", "ipv4://localhost:10302")
+	grepFailedExit(out.String(), "posting analysis")
+	fmt.Println("OK!")
+
+	fmt.Print("testing push...")
+	out = runCli(ctx, "push", "ipv4://localhost:10302")
+	grepFailedExit(out.String(), "dummy comment for push event")
+	fmt.Println("OK!")
+
+	// next tests require analyzier started with UAST, restart analyzer
+	stop()
+	ctx, timeoutCancel = context.WithTimeout(context.Background(), timeout)
+	defer timeoutCancel()
+	startDummy(ctx, "--uast")
+
+	fmt.Print("should return error without bblfsh...")
+	out = runCli(ctx, "review", "ipv4://localhost:10302", "--bblfshd=ipv4://localhost:0000")
+	grepFailedExit(out.String(), "WantUAST isn't allowed")
+	fmt.Println("OK!")
+
+	fmt.Print("should notify about lack of uast...")
+	out = runCli(ctx, "review", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
+	grepFailedExit(out.String(), "The file doesn't have UAST")
+	fmt.Println("OK!")
+
+	stop()
+}
+
+func runCli(ctx context.Context, cmd string, args ...string) bytes.Buffer {
+	args = append([]string{cmd}, args...)
+
+	var out bytes.Buffer
+	reviewCmd := exec.CommandContext(ctx, lookoutBin, args...)
+	reviewCmd.Stdout = &out
+	reviewCmd.Stderr = &out
+	handleErr(reviewCmd.Run(), "review command returned error", out)
+	return out
+}
+
+func startDummy(ctx context.Context, args ...string) {
+	args = append([]string{"serve"}, args...)
+
+	analyzerOut.Reset()
+
+	ctx, cancel := context.WithCancel(ctx)
+	stop = func() {
+		cancel()
+		fmt.Println("stopping sevices")
+		time.Sleep(time.Second) // go needs a bit of time to kill process
+	}
+
+	analyzerCmd := exec.CommandContext(ctx, dummyBin, args...)
+	analyzerCmd.Stdout = &analyzerOut
+	analyzerCmd.Stderr = &analyzerOut
+	err := analyzerCmd.Start()
+	if err != nil {
+		fmt.Println("can't start analyzer:")
+		fmt.Println(err)
+		fmt.Printf("output:\n %s", analyzerOut.String())
+		os.Exit(1)
+	} else {
+		go func() {
+			if err := analyzerCmd.Wait(); err != nil {
+				// don't print error if analyzer was killed by cancel
+				if ctx.Err() != context.Canceled {
+					fmt.Println("analyzer exited with error:", err)
+					fmt.Printf("output:\n%s", analyzerOut.String())
+					failExit()
+				}
+			}
+		}()
+	}
+}
+
+func handleErr(err error, desc string, out bytes.Buffer) {
+	if err == nil {
+		return
+	}
+
+	fmt.Printf("%s:\n", desc)
+	fmt.Println(err)
+	fmt.Printf("output:\n %s", out.String())
+	fmt.Printf("analyzer output\n %s", analyzerOut.String())
+	failExit()
+}
+
+func grepFailedExit(content, msg string) {
+	if !strings.Contains(content, msg) {
+		fmt.Printf("'%s' not found in:\n%s", msg, content)
+		fmt.Printf("analyzer output\n %s", analyzerOut.String())
+		failExit()
+	}
+}
+
+func failExit() {
+	stop()
+
+	os.Exit(1)
+}
+
+func readEnv() {
+	if os.Getenv("DUMMY_BIN") != "" {
+		dummyBin = os.Getenv("DUMMY_BIN")
+	}
+	if os.Getenv("LOOKOUT_BIN") != "" {
+		lookoutBin = os.Getenv("LOOKOUT_BIN")
+	}
+}


### PR DESCRIPTION
Fix: #45 

I think it's easier to write such tests in go than in shell scripts.

Docker for example also uses go for integration testing:
https://github.com/moby/moby/tree/master/integration-cli

There is no docker in macOS image in travis. I have removed that section completely. I'm not sure we really need to test it 2 times. Go suppose to work cross platform... But let me know if you think otherwise. We can try to add a simpler test for macOs that doesn't require docker.