### PR TITLE
Docker images for lookout and dummy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 
 stages:
   - name: tests
-  - name: release to github
+  - name: release
     if: tag IS present
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
         - export PY_OUT_DIR=py
         - mkdir -p "$PY_OUT_DIR" && python3 -m grpc_tools.protoc -Isdk --python_out=$PY_OUT_DIR --grpc_python_out=$PY_OUT_DIR sdk/*.proto
       name: "Protobuf code generation"
-    - stage: release to github
+    - stage: release
       name: "linux packages"
       script: PKG_OS="linux" make packages-sdk
       deploy: &deploy_anchor
@@ -66,13 +66,18 @@ jobs:
         skip_cleanup: true
         on:
           all_branches: true
-    - stage: release to github
+    - stage: release
       name: "macOS packages"
       os: osx
       osx_image: xcode9.4
       before_install: skip
       script: PKG_OS="darwin" make packages-sdk
       deploy: *deploy_anchor
+    - stage: release
+      name: "push image to Docker Hub"
+      script:
+        - PKG_OS=linux make build
+        - DOCKER_PUSH_LATEST=true make docker-push
 
 before_cache:
   # make bblfsh images readable

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
+# Main dockerfile
+DOCKERFILES=./docker/Dockerfile:$(PROJECT)
+
 # Environment
 OS := $(shell uname)
 CONFIG_FILE := config.yml

--- a/Makefile.dummy
+++ b/Makefile.dummy
@@ -1,0 +1,15 @@
+# Package configuration
+PROJECT = lookout-dummy-analyzer
+COMMANDS = cmd/dummy
+
+# Including ci Makefile
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_BRANCH ?= v1
+CI_PATH ?= .ci
+MAKEFILE := $(CI_PATH)/Makefile.main
+$(MAKEFILE):
+	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
+-include $(MAKEFILE)
+
+# Dummy analyzer dockerfile
+DOCKERFILES=./docker/Dockerfile.dummy:$(PROJECT)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:stretch-slim
+
+ADD ./build/bin/lookout /bin/lookout
+
+ENTRYPOINT ["/bin/lookout"]
+CMD [ "serve" ]

--- a/docker/Dockerfile.dummy
+++ b/docker/Dockerfile.dummy
@@ -1,0 +1,6 @@
+FROM debian:stretch-slim
+
+ADD ./build/bin/dummy /bin/dummy
+
+ENTRYPOINT ["/bin/dummy"]
+CMD [ "serve" ]


### PR DESCRIPTION
Fix #79.

Add 2 dockerfiles for `lookout` and `dummy`. Only the lookout docker image is set to be released on tag by travis.

With the new `Makefile.dummy` we can use the common `docker-build` or `docker-push` targets, as easy as:
```bash
$ make -f Makefile.dummy docker-push
```