### PR TITLE
Add a footnote with link to provide feedback on each comment

### DIFF
--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -1,3 +1,8 @@
 analyzers:
   - name: Dummy
     addr: ipv4://localhost:10302
+    # feedback: url to link in the comment_footer. For example, to open a new GitHub issue
+
+providers:
+  github:
+    comment_footer: "_If you have feedback about this comment, please, [tell us](%s)._"

--- a/poster.go
+++ b/poster.go
@@ -30,7 +30,7 @@ func (st AnalysisStatus) String() string {
 // Poster can post comments about an event.
 type Poster interface {
 	// Post posts comments about an event.
-	Post(context.Context, Event, []*Comment) error
+	Post(context.Context, Event, []AnalyzerComments) error
 
 	// Status sends the current analysis status to the provider
 	Status(context.Context, Event, AnalysisStatus) error

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -19,6 +19,11 @@ import (
 
 const Provider = "github"
 
+// ProviderConfig represents the yml config
+type ProviderConfig struct {
+	CommentFooter string `yaml:"comment_footer"`
+}
+
 // don't call github more often than
 var minInterval = 2 * time.Second
 

--- a/provider/json/poster.go
+++ b/provider/json/poster.go
@@ -27,11 +27,13 @@ func NewPoster(w io.Writer) *Poster {
 
 // Post prints json comments to sdtout
 func (p *Poster) Post(ctx context.Context, e lookout.Event,
-	comments []*lookout.Comment) error {
+	aCommentsList []lookout.AnalyzerComments) error {
 
-	for _, c := range comments {
-		if err := p.enc.Encode(c); err != nil {
-			return err
+	for _, a := range aCommentsList {
+		for _, c := range a.Comments {
+			if err := p.enc.Encode(c); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/provider/json/poster_test.go
+++ b/provider/json/poster_test.go
@@ -50,7 +50,14 @@ func TestPoster_Post_OK(t *testing.T) {
 		Text: "This is a another global comment",
 	}}
 
-	err := p.Post(context.Background(), ev, cs)
+	aCommentsList := []lookout.AnalyzerComments{lookout.AnalyzerComments{
+		Config: lookout.AnalyzerConfig{
+			Name: "mock",
+		},
+		Comments: cs,
+	}}
+
+	err := p.Post(context.Background(), ev, aCommentsList)
 	require.NoError(err)
 
 	expected := `{"text":"This is a global comment"}

--- a/server_test.go
+++ b/server_test.go
@@ -273,12 +273,18 @@ func (w *WatcherMock) Send(e Event) error {
 	return w.handler(e)
 }
 
+var _ Poster = &PosterMock{}
+
 type PosterMock struct {
 	comments []*Comment
 	status   AnalysisStatus
 }
 
-func (p *PosterMock) Post(_ context.Context, e Event, cs []*Comment) error {
+func (p *PosterMock) Post(_ context.Context, e Event, aCommentsList []AnalyzerComments) error {
+	cs := make([]*Comment, 0)
+	for _, aComments := range aCommentsList {
+		cs = append(cs, aComments.Comments...)
+	}
 	p.comments = cs
 	return nil
 }


### PR DESCRIPTION
Fix #84.

Adds a footnote to each comment with a link to provide feedback on the analyzer.
Please note the feedback link is supposed to be different for each analyzer, that's why the new `AnalyzerComments` is needed.

I figured the `comment_footer` config makes sense for each provider. For example GitHub understands markdown, but other future providers may need to provide a link with html markup.