### PR TITLE
support multiple tokens in watcher

### DIFF
--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -146,11 +146,7 @@ func (c *ServeCommand) initPoster(conf Config) (lookout.Poster, error) {
 func (c *ServeCommand) initWatcher(conf Config) (lookout.Watcher, error) {
 	switch c.Provider {
 	case github.Provider:
-		t := &roundTripper{
-			Log:      log.DefaultLogger,
-			User:     c.GithubUser,
-			Password: c.GithubToken,
-		}
+		t := github.NewTokenTransport(c.GithubUser, c.GithubToken, nil)
 
 		watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
 			URLs: strings.Split(c.Positional.Repository, ","),

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -6,3 +6,9 @@ analyzers:
 providers:
   github:
     comment_footer: "_If you have feedback about this comment, please, [tell us](%s)._"
+
+repositories:
+  - url: github.com/src-d/lookout
+    provider:
+      user:
+      token:

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"net/http"
+
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// Transport returns RoundTripper for a repository
+type Transport interface {
+	Get(repo string) http.RoundTripper
+}
+
+// TODO replace with github installation transport later
+
+// TokenTransport returns RoundTripper for a repository based on pre-configured tokens
+type TokenTransport struct {
+	UserToken
+	perRepo map[string]UserToken
+	rts     map[string]http.RoundTripper
+}
+
+// UserToken holds github username and token
+type UserToken struct {
+	user  string
+	token string
+}
+
+// NewTokenTransport creates new TokenTransport
+func NewTokenTransport(user, token string, perRepo map[string]UserToken) *TokenTransport {
+	if perRepo == nil {
+		perRepo = make(map[string]UserToken)
+	}
+
+	return &TokenTransport{UserToken: UserToken{user, token}, perRepo: perRepo}
+}
+
+// Get implements Transport interface
+func (t *TokenTransport) Get(repo string) http.RoundTripper {
+	rt, ok := t.rts[repo]
+	if !ok {
+		rt = t.create(repo)
+		t.rts[repo] = rt
+	}
+
+	return rt
+}
+
+func (t *TokenTransport) create(repo string) http.RoundTripper {
+	user := t.user
+	token := t.token
+
+	ut, ok := t.perRepo[repo]
+	if ok {
+		user = ut.user
+		token = ut.token
+	}
+
+	return &roundTripper{
+		Log:      log.DefaultLogger,
+		User:     user,
+		Password: token,
+	}
+}
+
+type roundTripper struct {
+	Log      log.Logger
+	Base     http.RoundTripper
+	User     string
+	Password string
+}
+
+func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.Log.With(log.Fields{
+		"url":  req.URL.String(),
+		"user": t.User,
+	}).Debugf("http request")
+
+	if t.User != "" {
+		req.SetBasicAuth(t.User, t.Password)
+	}
+
+	rt := t.Base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	return rt.RoundTrip(req)
+}
+
+var _ http.RoundTripper = &roundTripper{}


### PR DESCRIPTION
start working on #78 though now we use different api to get pull requests, so the original issue isn't very relevant anymore. Delay in `push` events isn't critical for us.

What is relevant - we need to support multiple transports/tokens for different repositories (transports are going to be github apps installations that issue tokens later)

this PR implements support for multiple tokens in watcher. But don't read them from configuration yet (but I updated yml file with example)

There are no tests for TokenTransport because I assume it will be replaced by apps transport pretty soon.

Current plan for work after this PR:
- calculate pull intervals based on transport (there are limits per user for tokens and per installation for apps tokens)
- use github.Transport in Poster
- read configuration from yml file
