### PR TITLE
support multiple tokens

### DIFF
--- a/cmd/lookout/serve.go
+++ b/cmd/lookout/serve.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"strings"
 
+	"github.com/gregjones/httpcache/diskcache"
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/provider/github"
 	"github.com/src-d/lookout/provider/json"
@@ -17,6 +17,7 @@ import (
 	"github.com/src-d/lookout/service/git"
 	"github.com/src-d/lookout/store"
 	"github.com/src-d/lookout/store/models"
+	"github.com/src-d/lookout/util/cache"
 	"github.com/src-d/lookout/util/cli"
 	"github.com/src-d/lookout/util/grpchelper"
 
@@ -51,6 +52,7 @@ type ServeCommand struct {
 	} `positional-args:"yes" required:"yes"`
 
 	analyzers map[string]lookout.AnalyzerClient
+	pool      *github.ClientPool
 }
 
 // Config holds the main configuration
@@ -95,6 +97,11 @@ func (c *ServeCommand) Execute(args []string) error {
 		}
 	}
 
+	err = c.initProvider()
+	if err != nil {
+		return err
+	}
+
 	poster, err := c.initPoster(conf)
 	if err != nil {
 		return err
@@ -124,6 +131,31 @@ func (c *ServeCommand) Execute(args []string) error {
 	return server.NewServer(watcher, poster, dataHandler.FileGetter, analyzers, eventOp, commentsOp).Run(ctx)
 }
 
+func (c *ServeCommand) initProvider() error {
+	switch c.Provider {
+	case github.Provider:
+		urls := strings.Split(c.Positional.Repository, ",")
+		urlTokens := make(map[string]github.UserToken, len(urls))
+		for _, url := range urls {
+			// TODO(max): read from yml
+			urlTokens[url] = github.UserToken{}
+		}
+
+		cache := cache.NewValidableCache(diskcache.New("/tmp/github"))
+		pool, err := github.NewClientPoolFromTokens(urlTokens, github.UserToken{
+			User:  c.GithubUser,
+			Token: c.GithubToken,
+		}, cache)
+		if err != nil {
+			return err
+		}
+
+		c.pool = pool
+	}
+
+	return nil
+}
+
 func (c *ServeCommand) initPoster(conf Config) (lookout.Poster, error) {
 	if c.DryRun {
 		return &LogPoster{log.DefaultLogger}, nil
@@ -131,13 +163,7 @@ func (c *ServeCommand) initPoster(conf Config) (lookout.Poster, error) {
 
 	switch c.Provider {
 	case github.Provider:
-		return github.NewPoster(
-			&roundTripper{
-				Log:      log.DefaultLogger,
-				User:     c.GithubUser,
-				Password: c.GithubToken,
-			},
-			conf.Providers.Github), nil
+		return github.NewPoster(c.pool, conf.Providers.Github), nil
 	case json.Provider:
 		return json.NewPoster(os.Stdout), nil
 	default:
@@ -148,13 +174,7 @@ func (c *ServeCommand) initPoster(conf Config) (lookout.Poster, error) {
 func (c *ServeCommand) initWatcher(conf Config) (lookout.Watcher, error) {
 	switch c.Provider {
 	case github.Provider:
-		t := &roundTripper{
-			Log:      log.DefaultLogger,
-			User:     c.GithubUser,
-			Password: c.GithubToken,
-		}
-
-		watcher, err := github.NewWatcher(t, &lookout.WatchOptions{
+		watcher, err := github.NewWatcher(c.pool, &lookout.WatchOptions{
 			URLs: strings.Split(c.Positional.Repository, ","),
 		})
 		if err != nil {
@@ -308,30 +328,3 @@ func (p *LogPoster) Status(ctx context.Context, e lookout.Event,
 	p.Log.Infof("status: %s", status)
 	return nil
 }
-
-type roundTripper struct {
-	Log      log.Logger
-	Base     http.RoundTripper
-	User     string
-	Password string
-}
-
-func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	t.Log.With(log.Fields{
-		"url":  req.URL.String(),
-		"user": t.User,
-	}).Debugf("http request")
-
-	if t.User != "" {
-		req.SetBasicAuth(t.User, t.Password)
-	}
-
-	rt := t.Base
-	if rt == nil {
-		rt = http.DefaultTransport
-	}
-
-	return rt.RoundTrip(req)
-}
-
-var _ http.RoundTripper = &roundTripper{}

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -9,6 +9,6 @@ providers:
 
 repositories:
   - url: github.com/src-d/lookout
-    provider:
+    auth:
       user:
       token:

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -6,3 +6,9 @@ analyzers:
 providers:
   github:
     comment_footer: "_If you have feedback about this comment, please, [tell us](%s)._"
+
+repositories:
+  - url: github.com/src-d/lookout
+    provider:
+      user:
+      token:

--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -1,0 +1,191 @@
+package github
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/github"
+	"github.com/gregjones/httpcache"
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/cache"
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// ClientPool holds mapping of repositories to clients
+type ClientPool struct {
+	byClients map[*Client][]*lookout.RepositoryInfo
+	byRepo    map[string]*Client
+}
+
+// Clients returns map[Client]RepositoryInfo
+func (p *ClientPool) Clients() map[*Client][]*lookout.RepositoryInfo {
+	return p.byClients
+}
+
+// Client returns client, ok by username and repository name
+func (p *ClientPool) Client(username, repo string) (*Client, bool) {
+	c, ok := p.byRepo[username+"/"+repo]
+	return c, ok
+}
+
+// Client is a wrapper for github.Client that supports cache and provides rate limit information
+type Client struct {
+	*github.Client
+	cache   *cache.ValidableCache
+	limitRT *limitRoundTripper
+}
+
+// NewClient creates new Client
+func NewClient(t http.RoundTripper, cache *cache.ValidableCache, l log.Logger) *Client {
+	limitRT := &limitRoundTripper{
+		Base: t,
+		Log:  l,
+	}
+
+	cachedT := httpcache.NewTransport(cache)
+	cachedT.MarkCachedResponses = true
+	cachedT.Transport = limitRT
+
+	return &Client{
+		Client:  github.NewClient(&http.Client{Transport: cachedT}),
+		cache:   cache,
+		limitRT: limitRT,
+	}
+}
+
+// Rate returns last github.Rate for a client by category
+func (c *Client) Rate(cat rateLimitCategory) github.Rate {
+	return c.limitRT.Rate(cat)
+}
+
+// PollInterval returns last duration from X-Poll-Interval for a client by category
+func (c *Client) PollInterval(cat pollLimitCategory) time.Duration {
+	return c.limitRT.PollInterval(cat)
+}
+
+// Validate validates cache by path
+func (c *Client) Validate(path string) error {
+	return c.cache.Validate(path)
+}
+
+type rateLimitCategory uint8
+type pollLimitCategory uint8
+
+const (
+	headerRateLimit     = "X-RateLimit-Limit"
+	headerRateRemaining = "X-RateLimit-Remaining"
+	headerRateReset     = "X-RateLimit-Reset"
+	headerPollInterval  = "X-Poll-Interval"
+)
+
+const (
+	coreCategory rateLimitCategory = iota
+	searchCategory
+
+	categories // An array of this length will be able to contain all rate limit categories.
+)
+
+const (
+	eventsCategory pollLimitCategory = iota
+	notificationsCategory
+	unknownCategory // in case some new endpoint starts return X-Poll-Interval
+
+	pollCategories
+)
+
+// category returns the rate limit category of the endpoint, determined by Request.URL.Path.
+func category(path string) rateLimitCategory {
+	switch {
+	default:
+		return coreCategory
+	case strings.HasPrefix(path, "/search/"):
+		return searchCategory
+	}
+}
+
+// pollCategory returns the poll limit category of the endpoint, determined by Request.URL.Path.
+// TODO(max): cover all cases
+func pollCategory(path string) pollLimitCategory {
+	switch {
+	case strings.HasSuffix(path, "/events"):
+		return eventsCategory
+	case strings.HasSuffix(path, "/notifications"):
+		return notificationsCategory
+	default:
+		return unknownCategory
+	}
+}
+
+type limitRoundTripper struct {
+	Base http.RoundTripper
+	Log  log.Logger
+
+	// rateLimits for the client as determined by the most recent API calls.
+	rateLimits [categories]github.Rate
+	// pollInterval for the client by endpoint as determined by the most recent API calls
+	pollIntervals [pollCategories]time.Duration
+
+	rateMu sync.Mutex
+}
+
+func (t *limitRoundTripper) Rate(c rateLimitCategory) github.Rate {
+	t.rateMu.Lock()
+	defer t.rateMu.Unlock()
+	return t.rateLimits[c]
+}
+
+func (t *limitRoundTripper) PollInterval(c pollLimitCategory) time.Duration {
+	t.rateMu.Lock()
+	defer t.rateMu.Unlock()
+	return t.pollIntervals[c]
+}
+
+func (t *limitRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := t.Base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	logFields := log.Fields{}
+
+	t.rateMu.Lock()
+	rate := t.rateLimits[category(req.URL.Path)]
+	if limit := resp.Header.Get(headerRateLimit); limit != "" {
+		rate.Limit, _ = strconv.Atoi(limit)
+		logFields["rate-limit"] = rate.Limit
+	}
+
+	if remaining := resp.Header.Get(headerRateRemaining); remaining != "" {
+		rate.Remaining, _ = strconv.Atoi(remaining)
+		logFields["rate-limit"] = rate.Remaining
+	}
+
+	if reset := resp.Header.Get(headerRateReset); reset != "" {
+		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
+			rate.Reset = github.Timestamp{time.Unix(v, 0)}
+		}
+		logFields["reset-at"] = rate.Reset
+	}
+
+	if pollInterval := resp.Header.Get(headerPollInterval); pollInterval != "" {
+		secs, _ := strconv.Atoi(pollInterval)
+		duration := time.Duration(secs) * time.Second
+		t.pollIntervals[pollCategory(req.URL.Path)] = duration
+		logFields["poll-interval"] = duration
+	}
+	t.rateMu.Unlock()
+
+	t.Log.With(logFields).Debugf("http request to %s", req.URL.Path)
+
+	return resp, err
+}
+
+var _ http.RoundTripper = &limitRoundTripper{}

--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -181,6 +181,8 @@ func (t *limitRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		t.pollIntervals[pollCategory(req.URL.Path)] = duration
 		logFields["poll-interval"] = duration
 	}
+
+	t.rateLimits[category(req.URL.Path)] = rate
 	t.rateMu.Unlock()
 
 	t.Log.With(logFields).Debugf("http request to %s", req.URL.Path)

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"net/http"
+
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/cache"
+	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// UserToken holds github username and token
+type UserToken struct {
+	User  string
+	Token string
+}
+
+// NewClientPoolFromTokens creates new ClientPool based on map[repoURL]UserToken
+// later we will need another constructor that would request installations and create pool from it
+func NewClientPoolFromTokens(urls map[string]UserToken, defaultToken UserToken, cache *cache.ValidableCache) (*ClientPool, error) {
+	byToken := make(map[UserToken][]*lookout.RepositoryInfo)
+	emptyToken := UserToken{}
+
+	for url, ut := range urls {
+		repo, err := vcsurl.Parse(url)
+		if err != nil {
+			return nil, err
+		}
+
+		if ut == emptyToken {
+			ut = defaultToken
+		}
+
+		byToken[ut] = append(byToken[ut], repo)
+	}
+
+	byClients := make(map[*Client][]*lookout.RepositoryInfo, len(byToken))
+	byRepo := make(map[string]*Client, len(urls))
+	for token, repos := range byToken {
+		client := NewClient(&roundTripper{
+			Log:      log.DefaultLogger,
+			User:     token.User,
+			Password: token.Token,
+		}, cache, log.DefaultLogger)
+
+		if _, ok := byClients[client]; !ok {
+			byClients[client] = []*lookout.RepositoryInfo{}
+		}
+
+		byClients[client] = append(byClients[client], repos...)
+		for _, r := range repos {
+			byRepo[r.FullName] = client
+		}
+	}
+
+	pool := &ClientPool{
+		byClients: byClients,
+		byRepo:    byRepo,
+	}
+	return pool, nil
+}
+
+type roundTripper struct {
+	Log      log.Logger
+	Base     http.RoundTripper
+	User     string
+	Password string
+}
+
+func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.Log.With(log.Fields{
+		"url":  req.URL.String(),
+		"user": t.User,
+	}).Debugf("http request")
+
+	if t.User != "" {
+		req.SetBasicAuth(t.User, t.Password)
+	}
+
+	rt := t.Base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	return rt.RoundTrip(req)
+}
+
+var _ http.RoundTripper = &roundTripper{}

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -248,7 +248,7 @@ func (w *Watcher) newInterval(rate github.Rate) time.Duration {
 	if remaining > 0 {
 		secs := int(rate.Reset.Sub(time.Now()).Seconds() / float64(remaining))
 		interval = time.Duration(secs) * time.Second
-	} else {
+	} else if !rate.Reset.IsZero() {
 		interval = rate.Reset.Sub(time.Now())
 	}
 

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -92,7 +92,7 @@ func (s *WatcherTestSuite) TestWatch() {
 	defer cancel()
 
 	err = w.Watch(ctx, func(e lookout.Event) error {
-		events++
+		atomic.AddInt32(&events, 1)
 
 		switch e.Type() {
 		case pb.ReviewEventType:
@@ -173,13 +173,13 @@ func (s *WatcherTestSuite) TestWatchLimit() {
 
 	err = w.Watch(ctx, func(e lookout.Event) error {
 		prEvents++
-		s.Equal("02b508226b9c2f38be7d589fe765a119ddf4452b", e.ID().String())
+		s.Equal("fd84071093b69f9aac25fb5dfeea1a870e3e19cf", e.ID().String())
 
 		return nil
 	})
 
-	s.Equal(1, atomic.LoadInt32(&calls))
-	s.Equal(1, prEvents)
+	s.EqualValues(1, atomic.LoadInt32(&calls))
+	s.EqualValues(1, prEvents)
 	s.EqualError(err, "context deadline exceeded")
 }
 

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/src-d/lookout/pb"
 	"github.com/src-d/lookout/util/cache"
 
-	"github.com/google/go-github/github"
 	"github.com/gregjones/httpcache"
 	"github.com/stretchr/testify/suite"
+	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 func init() {
@@ -26,10 +27,10 @@ func init() {
 
 type WatcherTestSuite struct {
 	suite.Suite
-	mux    *http.ServeMux
-	server *httptest.Server
-	client *github.Client
-	cache  *cache.ValidableCache
+	mux       *http.ServeMux
+	server    *httptest.Server
+	githubURL *url.URL
+	cache     *cache.ValidableCache
 }
 
 func (s *WatcherTestSuite) SetupTest() {
@@ -37,13 +38,7 @@ func (s *WatcherTestSuite) SetupTest() {
 	s.server = httptest.NewServer(s.mux)
 
 	s.cache = cache.NewValidableCache(httpcache.NewMemoryCache())
-	s.client = github.NewClient(&http.Client{
-		Transport: httpcache.NewTransport(s.cache),
-	})
-
-	url, _ := url.Parse(s.server.URL + "/")
-	s.client.BaseURL = url
-	s.client.UploadURL = url
+	s.githubURL, _ = url.Parse(s.server.URL + "/")
 }
 
 func (s *WatcherTestSuite) TestWatch() {
@@ -84,12 +79,11 @@ func (s *WatcherTestSuite) TestWatch() {
 	s.mux.HandleFunc("/repos/mock/test-b/pulls", pullsHandler(&callsB))
 	s.mux.HandleFunc("/repos/mock/test-b/events", eventsHandler(&callsB))
 
-	w, err := NewWatcher(nil, &lookout.WatchOptions{
-		URLs: []string{"github.com/mock/test-a", "github.com/mock/test-b"},
+	repoURLs := []string{"github.com/mock/test-a", "github.com/mock/test-b"}
+	poll := newTestPool(repoURLs, s.githubURL, s.cache)
+	w, err := NewWatcher(poll, &lookout.WatchOptions{
+		URLs: repoURLs,
 	})
-
-	w.c = s.client
-	w.cache = s.cache
 
 	s.NoError(err)
 
@@ -127,12 +121,11 @@ func (s *WatcherTestSuite) TestWatch_WithError() {
 		fmt.Fprint(w, `[{"id":"1", "type":"PushEvent", "payload":{"push_id": 1}}]`)
 	})
 
-	w, err := NewWatcher(nil, &lookout.WatchOptions{
-		URLs: []string{"github.com/mock/test"},
+	repoURLs := []string{"github.com/mock/test"}
+	poll := newTestPool(repoURLs, s.githubURL, s.cache)
+	w, err := NewWatcher(poll, &lookout.WatchOptions{
+		URLs: repoURLs,
 	})
-
-	w.c = s.client
-	w.cache = s.cache
 
 	s.NoError(err)
 
@@ -151,4 +144,36 @@ func (s *WatcherTestSuite) TearDownSuite() {
 
 func TestWatcherTestSuite(t *testing.T) {
 	suite.Run(t, new(WatcherTestSuite))
+}
+
+type NoopTransport struct{}
+
+func (t *NoopTransport) Get(repo string) http.RoundTripper {
+	return nil
+}
+
+func newTestPool(repoURLs []string, githubURL *url.URL, cache *cache.ValidableCache) *ClientPool {
+	client := NewClient(nil, cache, log.New(log.Fields{}))
+	client.BaseURL = githubURL
+	client.UploadURL = githubURL
+
+	byClients := map[*Client][]*lookout.RepositoryInfo{
+		client: []*lookout.RepositoryInfo{},
+	}
+	byRepo := make(map[string]*Client, len(repoURLs))
+
+	for _, url := range repoURLs {
+		repo, err := vcsurl.Parse(url)
+		if err != nil {
+			panic(err)
+		}
+
+		byClients[client] = append(byClients[client], repo)
+		byRepo[repo.FullName] = client
+	}
+
+	return &ClientPool{
+		byClients: byClients,
+		byRepo:    byRepo,
+	}
 }

--- a/util/cache/validable.go
+++ b/util/cache/validable.go
@@ -37,7 +37,9 @@ func (c *ValidableCache) Set(key string, responseBytes []byte) {
 
 // Validate validates the given key as a valid cache entry,
 func (c *ValidableCache) Validate(key string) error {
+	c.m.Lock()
 	content, ok := c.inMem[key]
+	c.m.Unlock()
 	if !ok {
 		return ErrNotFoundKey.New(key)
 	}


### PR DESCRIPTION
start working on #78 though now we use different api to get pull requests, so the original issue isn't very relevant anymore. Delay in push events isn't critical for us.

What is relevant - we need to support multiple transports/tokens for different repositories (transports are going to be github apps installations that issue tokens later)

Coverage did decrease but not as codecov shows it. It decreased mostly because of `NewClientPoolFromTokens` that suppose to be temporary.