### PR TITLE
Fix github PR ID cast to string

### DIFF
--- a/provider/github/utils.go
+++ b/provider/github/utils.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/src-d/lookout"
 
@@ -67,7 +68,8 @@ func castHash(sha1 *string) plumbing.Hash {
 func castPullRequest(r *lookout.RepositoryInfo, pr *github.PullRequest) *lookout.ReviewEvent {
 	pre := &lookout.ReviewEvent{}
 	pre.Provider = Provider
-	pre.InternalID = string(pr.GetID())
+	pre.InternalID = strconv.FormatInt(pr.GetID(), 10)
+
 	pre.Number = uint32(pr.GetNumber())
 	pre.RepositoryID = uint32(pr.GetHead().GetRepo().GetID())
 	pre.Source = castPullRequestBranch(pr.GetHead())

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -99,7 +99,7 @@ func (s *WatcherTestSuite) TestWatch() {
 		switch e.Type() {
 		case pb.ReviewEventType:
 			prEvents++
-			s.Equal("02b508226b9c2f38be7d589fe765a119ddf4452b", e.ID().String())
+			s.Equal("fd84071093b69f9aac25fb5dfeea1a870e3e19cf", e.ID().String())
 		case pb.PushEventType:
 			pushEvents++
 			s.Equal("d1f57cc4e520766576c5f1d9e7655aeea5fbccfa", e.ID().String())


### PR DESCRIPTION
Testing on a real github repository, I was getting the same event-id reported in the logs for 2 different github PRs.

```
[2018-08-08T11:48:01.620369587+02:00]  INFO event successfully processed, skipping... event-id=a29ea85b92358e61e3a56281c5f6e885fa170ab7 event-type=2 source=server/server.go:62
[2018-08-08T11:48:01.620912275+02:00]  INFO event successfully processed, skipping... event-id=a29ea85b92358e61e3a56281c5f6e885fa170ab7 event-type=2 source=server/server.go:62
```

With some logs I saw that the string casting was producing some unicode
```
[2018-08-08T11:48:01.618595027+02:00] DEBUG castPullRequest pr.GetID=206773903 pre.InternalID=� source=github/utils.go:78
```

After the change in this PR the ids match:

```
[2018-08-08T11:51:40.137916423+02:00] DEBUG castPullRequest pr.GetID=206773903 pre.InternalID=206773903 source=github/utils.go:79
```