### PR TITLE
Check DB version on lookout serve start

### DIFF
--- a/cmd/lookout/migrate.go
+++ b/cmd/lookout/migrate.go
@@ -5,8 +5,6 @@ import (
 	"github.com/src-d/lookout/util/cli"
 
 	"github.com/golang-migrate/migrate"
-	_ "github.com/golang-migrate/migrate/database/postgres"
-	bindata "github.com/golang-migrate/migrate/source/go-bindata"
 	log "gopkg.in/src-d/go-log.v1"
 )
 
@@ -23,17 +21,7 @@ type MigrateCommand struct {
 }
 
 func (c *MigrateCommand) Execute(args []string) error {
-	s := bindata.Resource(store.AssetNames(),
-		func(name string) ([]byte, error) {
-			return store.Asset(name)
-		})
-
-	d, err := bindata.WithInstance(s)
-	if err != nil {
-		return err
-	}
-
-	m, err := migrate.NewWithSourceInstance("go-bindata", d, c.DB)
+	m, err := store.NewMigrateDSN(c.DB)
 	if err != nil {
 		return err
 	}

--- a/store/migrations.go
+++ b/store/migrations.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/golang-migrate/migrate"
+	"github.com/golang-migrate/migrate/database/postgres"
+	"github.com/golang-migrate/migrate/source"
+	bindata "github.com/golang-migrate/migrate/source/go-bindata"
+)
+
+// NewMigrateDSN returns a new Migrate instance from a database URL
+func NewMigrateDSN(dsn string) (*migrate.Migrate, error) {
+	source, err := initSource()
+	if err != nil {
+		return nil, err
+	}
+
+	return migrate.NewWithSourceInstance("go-bindata", source, dsn)
+}
+
+// NewMigrateInstance returns a new Migrate instance from a postgres instance
+func NewMigrateInstance(db *sql.DB) (*migrate.Migrate, error) {
+	source, err := initSource()
+	if err != nil {
+		return nil, err
+	}
+
+	driver, err := postgres.WithInstance(db, &postgres.Config{})
+
+	return migrate.NewWithInstance("go-bindata", source, "postgres", driver)
+}
+
+func initSource() (source.Driver, error) {
+	s := bindata.Resource(AssetNames(),
+		func(name string) ([]byte, error) {
+			return Asset(name)
+		})
+
+	return bindata.WithInstance(s)
+}
+
+// MaxMigrateVersion returns the current DB migration file version
+func MaxMigrateVersion() (uint, error) {
+	var maxVersion uint64
+
+	names := AssetNames()
+	for _, name := range names {
+		if !strings.HasSuffix(name, "up.sql") {
+			continue
+		}
+
+		vStr := strings.Split(name, "_")[0]
+		vUint, err := strconv.ParseUint(vStr, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse migration version for file %s, %s", name, err)
+		}
+
+		if vUint > maxVersion {
+			maxVersion = vUint
+		}
+	}
+
+	return uint(maxVersion), nil
+}


### PR DESCRIPTION
Part of #100, replaces #108.

`lookout serve` checks the DB is initialized and the current migration version.