### PR TITLE
add logs into git service

### DIFF
--- a/service/bblfsh/bblfsh.go
+++ b/service/bblfsh/bblfsh.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 	"gopkg.in/bblfsh/sdk.v1/uast"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 // Service implements data service interface which adds UAST to the responses
@@ -95,6 +96,8 @@ func (s *BaseScanner) processFile(f *lookout.File) error {
 	if f == nil {
 		return nil
 	}
+
+	log.Debugf("parsing uast for file: %s", f.Path)
 
 	var err error
 	f.UAST, err = s.parseFile(f)

--- a/service/git/library.go
+++ b/service/git/library.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/storage"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 var (
@@ -49,6 +50,7 @@ func (l *Library) GetOrInit(url *lookout.RepositoryInfo) (
 
 // Init inits a new repository for the given URL.
 func (l *Library) Init(url *lookout.RepositoryInfo) (*git.Repository, error) {
+	log.Infof("creating local repository for: %s", url.CloneURL)
 	l.m.Lock()
 	defer l.m.Unlock()
 

--- a/service/git/service.go
+++ b/service/git/service.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 // Service implements data service interface on top of go-git
@@ -98,6 +99,8 @@ func (r *Service) loadTrees(ctx context.Context,
 	}
 
 	rps = append(rps, *head)
+
+	log.Debugf("load trees for references: %v", rps)
 
 	commits, err := r.loader.LoadCommits(ctx, rps...)
 	if err != nil {

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 // Syncer syncs the local copy of git repository for a given CommitRevision.
@@ -53,6 +54,8 @@ func (s *Syncer) Sync(ctx context.Context,
 }
 
 func (s *Syncer) fetch(ctx context.Context, repoURL string, r *git.Repository, refspecs []config.RefSpec) error {
+	log.Infof("fetching references for repository %s: %v", repoURL, refspecs)
+
 	opts := &git.FetchOptions{
 		RemoteName: "origin",
 		RefSpecs:   refspecs,


### PR DESCRIPTION
Fix: #112

I have inspected the source code and found only a few places where logs (at least without context) make sense.
Looks like anything else even with debug level would just pollute output.

More verbose debug information will be helpful only if the log is scoped to request/event.