### PR TITLE
Log context

### DIFF
--- a/dummy/dummy_test.go
+++ b/dummy/dummy_test.go
@@ -13,7 +13,12 @@ import (
 	"google.golang.org/grpc"
 	"gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+	log "gopkg.in/src-d/go-log.v1"
 )
+
+func init() {
+	log.DefaultLogger = log.New(log.Fields{"app": "dummy"})
+}
 
 type DummySuite struct {
 	suite.Suite

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -24,6 +24,7 @@ import (
 func init() {
 	// make everything faster for tests
 	minInterval = time.Millisecond
+	log.DefaultLogger = log.New(log.Fields{"app": "lookout"})
 }
 
 type WatcherTestSuite struct {

--- a/provider/json/poster.go
+++ b/provider/json/poster.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/ctxlog"
 	"gopkg.in/src-d/go-log.v1"
 )
 
@@ -44,6 +45,6 @@ func (p *Poster) Post(ctx context.Context, e lookout.Event,
 func (p *Poster) Status(ctx context.Context, e lookout.Event,
 	status lookout.AnalysisStatus) error {
 
-	log.With(log.Fields{"status": status}).Infof("New status")
+	ctxlog.Get(ctx).With(log.Fields{"status": status}).Infof("New status")
 	return nil
 }

--- a/provider/json/watcher_test.go
+++ b/provider/json/watcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/pb"
+	log "gopkg.in/src-d/go-log.v1"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -27,6 +28,10 @@ var (
 	badEvent   = `{"event":"none"}`
 	badJSON    = `{"event":"push", { ...`
 )
+
+func init() {
+	log.DefaultLogger = log.New(log.Fields{"app": "lookout"})
+}
 
 func (s *WatcherTestSuite) TestWatch() {
 	var events int

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/src-d/lookout/mock"
 	"github.com/src-d/lookout/pb"
 	"github.com/src-d/lookout/store"
+	"github.com/src-d/lookout/util/ctxlog"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	log "gopkg.in/src-d/go-log.v1"
@@ -333,7 +334,6 @@ func TestWatcherError(t *testing.T) {
 	require := require.New(t)
 
 	logMock := &MockLogger{}
-	log.DefaultLogger = logMock
 
 	watcher := &ErrorWatcherMock{}
 	poster := &PosterMock{}
@@ -347,6 +347,7 @@ func TestWatcherError(t *testing.T) {
 	srv := NewServer(watcher, poster, fileGetter, analyzers, &store.NoopEventOperator{}, &store.NoopCommentOperator{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx = ctxlog.Set(ctx, logMock)
 	defer cancel()
 
 	err := srv.Run(ctx)

--- a/service/git/service.go
+++ b/service/git/service.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/ctxlog"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
-	log "gopkg.in/src-d/go-log.v1"
 )
 
 // Service implements data service interface on top of go-git
@@ -100,7 +100,7 @@ func (r *Service) loadTrees(ctx context.Context,
 
 	rps = append(rps, *head)
 
-	log.Debugf("load trees for references: %v", rps)
+	ctxlog.Get(ctx).Debugf("load trees for references: %v", rps)
 
 	commits, err := r.loader.LoadCommits(ctx, rps...)
 	if err != nil {

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/ctxlog"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
@@ -55,11 +56,11 @@ func (s *Syncer) Sync(ctx context.Context,
 }
 
 func (s *Syncer) fetch(ctx context.Context, repoURL string, r *git.Repository, refspecs []config.RefSpec) (err error) {
-	log.Infof("fetching references for repository %s: %v", repoURL, refspecs)
+	ctxlog.Get(ctx).Infof("fetching references for repository %s: %v", repoURL, refspecs)
 	start := time.Now()
 	defer func() {
 		if err == nil {
-			log.
+			ctxlog.Get(ctx).
 				With(log.Fields{"duration": time.Now().Sub(start)}).
 				Debugf("references %v fetched for repository %s", repoURL, refspecs)
 		}

--- a/store/db.go
+++ b/store/db.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/store/models"
+	"github.com/src-d/lookout/util/ctxlog"
 	kallax "gopkg.in/src-d/go-kallax.v1"
-	log "gopkg.in/src-d/go-log.v1"
 )
 
 // DBEventOperator operates on event database store
@@ -31,7 +31,7 @@ func (o *DBEventOperator) Save(ctx context.Context, e lookout.Event) (models.Eve
 	case *lookout.PushEvent:
 		return o.savePush(ctx, ev)
 	default:
-		log.Debugf("ignoring unsupported event: %s", ev)
+		ctxlog.Get(ctx).Debugf("ignoring unsupported event: %s", ev)
 	}
 
 	return models.EventStatusNew, nil
@@ -45,7 +45,7 @@ func (o *DBEventOperator) UpdateStatus(ctx context.Context, e lookout.Event, sta
 	case *lookout.PushEvent:
 		return o.updatePushStatus(ctx, ev, status)
 	default:
-		log.Debugf("ignoring unsupported event: %s", ev)
+		ctxlog.Get(ctx).Debugf("ignoring unsupported event: %s", ev)
 		return nil
 	}
 }

--- a/util/ctxlog/context.go
+++ b/util/ctxlog/context.go
@@ -1,0 +1,32 @@
+package ctxlog
+
+import (
+	"context"
+
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+type ctxLogger int
+
+// LoggerKey is the key that holds logger in a context.
+const LoggerKey ctxLogger = 0
+
+// Get returns logger from context or DefaultLogger if there is no logger in context
+func Get(ctx context.Context) log.Logger {
+	if v := ctx.Value(LoggerKey); v != nil {
+		return v.(log.Logger)
+	}
+
+	return log.DefaultLogger
+}
+
+// WithLogFields returns context with new logger and the logger
+func WithLogFields(ctx context.Context, f log.Fields) (context.Context, log.Logger) {
+	logger := Get(ctx).With(f)
+	return Set(ctx, logger), logger
+}
+
+// Set puts logger into context and returns new context
+func Set(ctx context.Context, logger log.Logger) context.Context {
+	return context.WithValue(ctx, LoggerKey, logger)
+}


### PR DESCRIPTION
Fix: #125 

- Cleaner function signatures
- More informative logs especially for something like `empty pull request branch given`
- Bonus: no more complaining about races in logs from `go test -race`

There are very few places left where we still use global logger. Those are git/bblfsh services because they don't use context at all. (maybe we will want to change it later or maybe not)