### PR TITLE
Add github api http errors tests

### DIFF
--- a/provider/github/poster.go
+++ b/provider/github/poster.go
@@ -192,6 +192,7 @@ func (p *Poster) createReviewRequest(
 }
 
 // Status sets the Pull Request global status, visible from the GitHub UI
+// If a GitHub API request fails, ErrGitHubAPI is returned.
 func (p *Poster) Status(ctx context.Context, e lookout.Event, status lookout.AnalysisStatus) error {
 	switch ev := e.(type) {
 	case *lookout.ReviewEvent:
@@ -258,7 +259,11 @@ func (p *Poster) statusPR(ctx context.Context, e *lookout.ReviewEvent, status lo
 	}
 
 	_, _, err = client.Repositories.CreateStatus(ctx, owner, repo, e.CommitRevision.Head.Hash, repoStatus)
-	return err
+	if err != nil {
+		return ErrGitHubAPI.Wrap(err)
+	}
+
+	return nil
 }
 
 func (p *Poster) getClient(username, repository string) (*Client, error) {

--- a/provider/github/poster_test.go
+++ b/provider/github/poster_test.go
@@ -99,7 +99,7 @@ func (s *PosterTestSuite) SetupTest() {
 	githubURL, _ := url.Parse(s.server.URL + "/")
 
 	repoURLs := []string{"github.com/foo/bar"}
-	s.pool = newTestPool(repoURLs, githubURL, cache)
+	s.pool = newTestPool(s.Suite, repoURLs, githubURL, cache)
 }
 
 func (s *PosterTestSuite) TestPostOK() {

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -177,7 +177,9 @@ func (s *WatcherTestSuite) TestWatch_HttpTimeout() {
 	var calls, callsErr int32
 
 	// Change the request timeout for this test
+	prevRequestTimeout := RequestTimeout
 	RequestTimeout = 5 * minInterval
+	defer func() { RequestTimeout = prevRequestTimeout }()
 
 	errCodeHandler := func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&callsErr, 1)

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -42,65 +42,74 @@ func (s *WatcherTestSuite) SetupTest() {
 	s.githubURL, _ = url.Parse(s.server.URL + "/")
 }
 
+var pullsHandler = func(calls *int32) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+
+		etag := "124567"
+		if r.Header.Get("if-none-match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		w.Header().Set("etag", etag)
+		fmt.Fprint(w, `[{"id":5}]`)
+	}
+}
+
+var eventsHandler = func(calls *int32) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+
+		etag := "124567"
+		if r.Header.Get("if-none-match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		w.Header().Set("etag", etag)
+		fmt.Fprint(w, `[{"id":"1", "type":"PushEvent", "payload":{"push_id": 1}}]`)
+	}
+}
+
+const (
+	pullID = "fd84071093b69f9aac25fb5dfeea1a870e3e19cf"
+	pushID = "d1f57cc4e520766576c5f1d9e7655aeea5fbccfa"
+)
+
+func (s *WatcherTestSuite) newWatcher(repoURLs []string) *Watcher {
+	pool := newTestPool(s.Suite, repoURLs, s.githubURL, s.cache)
+	w, err := NewWatcher(pool, &lookout.WatchOptions{
+		URLs: repoURLs,
+	})
+
+	s.NoError(err)
+
+	return w
+}
+
 func (s *WatcherTestSuite) TestWatch() {
 	var callsA, callsB, events, prEvents, pushEvents int32
-
-	pullsHandler := func(calls *int32) func(w http.ResponseWriter, r *http.Request) {
-		return func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(calls, 1)
-
-			etag := "124567"
-			if r.Header.Get("if-none-match") == etag {
-				w.WriteHeader(http.StatusNotModified)
-				return
-			}
-
-			w.Header().Set("etag", etag)
-			fmt.Fprint(w, `[{"id":5}]`)
-		}
-	}
-
-	eventsHandler := func(calls *int32) func(w http.ResponseWriter, r *http.Request) {
-		return func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(calls, 1)
-
-			etag := "124567"
-			if r.Header.Get("if-none-match") == etag {
-				w.WriteHeader(http.StatusNotModified)
-				return
-			}
-
-			w.Header().Set("etag", etag)
-			fmt.Fprint(w, `[{"id":"1", "type":"PushEvent", "payload":{"push_id": 1}}]`)
-		}
-	}
 
 	s.mux.HandleFunc("/repos/mock/test-a/pulls", pullsHandler(&callsA))
 	s.mux.HandleFunc("/repos/mock/test-a/events", eventsHandler(&callsA))
 	s.mux.HandleFunc("/repos/mock/test-b/pulls", pullsHandler(&callsB))
 	s.mux.HandleFunc("/repos/mock/test-b/events", eventsHandler(&callsB))
 
-	repoURLs := []string{"github.com/mock/test-a", "github.com/mock/test-b"}
-	poll := newTestPool(repoURLs, s.githubURL, s.cache)
-	w, err := NewWatcher(poll, &lookout.WatchOptions{
-		URLs: repoURLs,
-	})
-
-	s.NoError(err)
-
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), minInterval*10)
 	defer cancel()
 
-	err = w.Watch(ctx, func(e lookout.Event) error {
+	w := s.newWatcher([]string{"github.com/mock/test-a", "github.com/mock/test-b"})
+	err := w.Watch(ctx, func(e lookout.Event) error {
 		atomic.AddInt32(&events, 1)
 
 		switch e.Type() {
 		case pb.ReviewEventType:
 			prEvents++
-			s.Equal("fd84071093b69f9aac25fb5dfeea1a870e3e19cf", e.ID().String())
+			s.Equal(pullID, e.ID().String())
 		case pb.PushEventType:
 			pushEvents++
-			s.Equal("d1f57cc4e520766576c5f1d9e7655aeea5fbccfa", e.ID().String())
+			s.Equal(pushID, e.ID().String())
 		}
 
 		return nil
@@ -114,24 +123,20 @@ func (s *WatcherTestSuite) TestWatch() {
 	s.EqualError(err, "context deadline exceeded")
 }
 
-func (s *WatcherTestSuite) TestWatch_WithError() {
-	s.mux.HandleFunc("/repos/mock/test/pulls", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `[{"id":1}]`)
-	})
-	s.mux.HandleFunc("/repos/mock/test/events", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `[{"id":"1", "type":"PushEvent", "payload":{"push_id": 1}}]`)
-	})
+func (s *WatcherTestSuite) TestWatch_CallbackError() {
+	var calls int32
 
-	repoURLs := []string{"github.com/mock/test"}
-	poll := newTestPool(repoURLs, s.githubURL, s.cache)
-	w, err := NewWatcher(poll, &lookout.WatchOptions{
-		URLs: repoURLs,
-	})
+	s.mux.HandleFunc("/repos/mock/test/pulls", pullsHandler(&calls))
+	s.mux.HandleFunc("/repos/mock/test/events", eventsHandler(&calls))
 
-	s.NoError(err)
-
-	err = w.Watch(context.TODO(), func(e lookout.Event) error {
-		s.Equal("d1f57cc4e520766576c5f1d9e7655aeea5fbccfa", e.ID().String())
+	w := s.newWatcher([]string{"github.com/mock/test"})
+	err := w.Watch(context.TODO(), func(e lookout.Event) error {
+		switch e.Type() {
+		case pb.ReviewEventType:
+			s.Equal(pullID, e.ID().String())
+		case pb.PushEventType:
+			s.Equal(pushID, e.ID().String())
+		}
 
 		return fmt.Errorf("foo")
 	})
@@ -160,18 +165,11 @@ func (s *WatcherTestSuite) TestWatchLimit() {
 
 	s.mux.HandleFunc("/repos/mock/test/pulls", pullsHandler(&calls))
 
-	repoURLs := []string{"github.com/mock/test"}
-	poll := newTestPool(repoURLs, s.githubURL, s.cache)
-	w, err := NewWatcher(poll, &lookout.WatchOptions{
-		URLs: repoURLs,
-	})
-
-	s.NoError(err)
-
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), minInterval*10)
 	defer cancel()
 
-	err = w.Watch(ctx, func(e lookout.Event) error {
+	w := s.newWatcher([]string{"github.com/mock/test"})
+	err := w.Watch(ctx, func(e lookout.Event) error {
 		prEvents++
 		s.Equal("fd84071093b69f9aac25fb5dfeea1a870e3e19cf", e.ID().String())
 
@@ -197,7 +195,7 @@ func (t *NoopTransport) Get(repo string) http.RoundTripper {
 	return nil
 }
 
-func newTestPool(repoURLs []string, githubURL *url.URL, cache *cache.ValidableCache) *ClientPool {
+func newTestPool(s suite.Suite, repoURLs []string, githubURL *url.URL, cache *cache.ValidableCache) *ClientPool {
 	client := NewClient(nil, cache, log.New(log.Fields{}))
 	client.BaseURL = githubURL
 	client.UploadURL = githubURL
@@ -209,9 +207,7 @@ func newTestPool(repoURLs []string, githubURL *url.URL, cache *cache.ValidableCa
 
 	for _, url := range repoURLs {
 		repo, err := vcsurl.Parse(url)
-		if err != nil {
-			panic(err)
-		}
+		s.NoError(err)
 
 		byClients[client] = append(byClients[client], repo)
 		byRepo[repo.FullName] = client


### PR DESCRIPTION
Fix #122.

There are many changes, but you can check the individual commits to make it easier to review.

Besides adding tests, there are the following changes in the code:
- `Watcher.Watch` does not exit for expected errors.
We already have a restart in `Server.Run`, but it also makes sense to deal with expected errors in the watcher. This is important because we many be polling several repositories in `Watcher.Watch`, and a network or auth error in only one request will stop all the other requests for other repos that may be working fine.
- `Watcher.watchEvents` uses `time.After(interval)` instead of `time.After(pollInterval)`. This was a bug, discussed via chat.
- `Poster.Status` uses the `ErrGitHubAPI` as return values, to make it similar to `Poster.Post`.