### PR TITLE
speedup ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         - make test-sdk
     - name: "Lookout serve Integration Tests Linux"
       script:
-      - make ci-install
+      - make prepare-services
       - psql -c 'create database lookout;' -U postgres
       - make build
       - ./build/bin/lookout migrate
@@ -44,7 +44,7 @@ jobs:
       - make test-json
     - name: "Lookout serve Integration Tests macOS"
       script:
-      - make ci-install
+      - make prepare-services
       - psql -c 'create database lookout;' -U postgres
       - make build
       - ./build/lookout_darwin_amd64/lookout migrate


### PR DESCRIPTION
install dependencies only when they are needed (generated code task):

before:
<img width="216" alt="screen shot 2018-08-13 at 18 43 38" src="https://user-images.githubusercontent.com/406916/44045443-d31dfe54-9f28-11e8-8157-6ca7924cea5f.png">

after:
<img width="205" alt="screen shot 2018-08-13 at 18 42 17" src="https://user-images.githubusercontent.com/406916/44045456-dabacdd6-9f28-11e8-83b8-3f934d8a29a7.png">
