### PR TITLE
Fix: skip missing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It includes a curl-style binary that allows to trigger Analyzers directly, witho
 The included [`./docker-compose.yml`](./docker-compose.yml) allows to start all dependencies using [Docker Compose](https://docs.docker.com/compose/) 
 
 * [bblfshd](https://github.com/bblfsh/bblfshd), on `localhost:9432`
-* [PostgreSQL](https://www.postgresql.org/), on `localhost:5432` password `example`
+* [PostgreSQL](https://www.postgresql.org/), on `localhost:5432` password `postgres`
 
 Clone the repository, or download [`./docker-compose.yml`](./docker-compose.yml)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: lookout
 volumes:
   drivers:

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -50,7 +50,7 @@ $ docker-compose up
 This will create the following Docker containers:
 
 * [bblfshd](https://github.com/bblfsh/bblfshd), listening on `localhost:9432`
-* [PostgreSQL](https://www.postgresql.org/), listening on `localhost:5432`, password `example`. _Note_: this will be a requirement for future functionality, it is not used right now.
+* [PostgreSQL](https://www.postgresql.org/), listening on `localhost:5432`, password `postgres`. _Note_: this will be a requirement for future functionality, it is not used right now.
 
 
 ### lookout SDK Commands

--- a/server/server.go
+++ b/server/server.go
@@ -191,6 +191,7 @@ func (s *Server) HandlePush(ctx context.Context, e *lookout.PushEvent) error {
 
 func (s *Server) getConfig(ctx context.Context, e lookout.Event) (map[string]lookout.AnalyzerConfig, error) {
 	rev := e.Revision()
+	ctxlog.Get(ctx).Infof("getting .lookout.yml")
 	scanner, err := s.fileGetter.GetFiles(ctx, &lookout.FilesRequest{
 		Revision:       &rev.Head,
 		IncludePattern: `^\.lookout\.yml$`,

--- a/service/git/scanner.go
+++ b/service/git/scanner.go
@@ -250,20 +250,20 @@ func (b *blobAdder) Fn(f *lookout.File) (bool, error) {
 
 	of, err := b.tree.File(f.Path)
 	if err != nil {
-		log.Warningf("skipping - can not get file:'%v', %v", f.Path, err)
+		log.Warningf("skipping - cannot get file:'%v', %v", f.Path, err)
 		return true, nil
 	}
 
 	r, err := of.Blob.Reader()
 	if err != nil {
-		return true, fmt.Errorf("can not get reader for file:'%v', %v", f.Path, err)
+		return true, fmt.Errorf("cannot get reader for file:'%v', %v", f.Path, err)
 	}
 
 	defer gitioutil.CheckClose(r, &err)
 
 	f.Content, err = ioutil.ReadAll(r)
 	if err != nil {
-		return true, fmt.Errorf("can not read file:'%v', %v", f.Path, err)
+		return true, fmt.Errorf("cannot read file:'%v', %v", f.Path, err)
 	}
 
 	return false, nil

--- a/service/git/scanner.go
+++ b/service/git/scanner.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"regexp"
@@ -248,19 +249,19 @@ func (b *blobAdder) Fn(f *lookout.File) (bool, error) {
 
 	of, err := b.tree.File(f.Path)
 	if err != nil {
-		return true, err
+		return true, fmt.Errorf("can not get file:'%v', %v", f.Path, err)
 	}
 
 	r, err := of.Blob.Reader()
 	if err != nil {
-		return true, err
+		return true, fmt.Errorf("can not get reader for file:'%v', %v", f.Path, err)
 	}
 
 	defer gitioutil.CheckClose(r, &err)
 
 	f.Content, err = ioutil.ReadAll(r)
 	if err != nil {
-		return true, err
+		return true, fmt.Errorf("can not read file:'%v', %v", f.Path, err)
 	}
 
 	return false, nil

--- a/service/git/scanner.go
+++ b/service/git/scanner.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	gitioutil "gopkg.in/src-d/go-git.v4/utils/ioutil"
+	log "gopkg.in/src-d/go-log.v1"
 )
 
 // TreeScanner is a scanner for files of git tree
@@ -249,7 +250,8 @@ func (b *blobAdder) Fn(f *lookout.File) (bool, error) {
 
 	of, err := b.tree.File(f.Path)
 	if err != nil {
-		return true, fmt.Errorf("can not get file:'%v', %v", f.Path, err)
+		log.Warningf("skipping - can not get file:'%v', %v", f.Path, err)
+		return true, nil
 	}
 
 	r, err := of.Blob.Reader()

--- a/util/cli/db.go
+++ b/util/cli/db.go
@@ -2,5 +2,5 @@ package cli
 
 // DBOptions contains common flags for commands using the DB
 type DBOptions struct {
-	DB string `long:"db" default:"postgres://postgres:example@localhost:5432/lookout?sslmode=disable" env:"LOOKOUT_DB" description:"connection string to postgres database"`
+	DB string `long:"db" default:"postgres://postgres:postgres@localhost:5432/lookout?sslmode=disable" env:"LOOKOUT_DB" description:"connection string to postgres database"`
 }

--- a/util/cmdtest/cmds.go
+++ b/util/cmdtest/cmds.go
@@ -149,7 +149,7 @@ func RunCli(ctx context.Context, cmd string, args ...string) io.Reader {
 
 // ResetDB recreates database for the test
 func ResetDB() {
-	db, err := sql.Open("postgres", "postgres://postgres:example@localhost:5432/lookout?sslmode=disable")
+	db, err := sql.Open("postgres", "postgres://postgres:postgres@localhost:5432/lookout?sslmode=disable")
 	if err != nil {
 		fmt.Println("can't connect to DB:", err)
 		os.Exit(1)


### PR DESCRIPTION
This is workaround for #144 :
 - log & skip files that do not have Blobs
 - default password for easier reproduction using `docker-compose`
 - a bit more verbose error messages


Better analysis and a long-term solution expected be proposed under #149 