### PR TITLE
Fix default auth

### DIFF
--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -25,17 +25,13 @@ func (c ClientConfig) IsZero() bool {
 
 // NewClientPoolFromTokens creates new ClientPool based on map[repoURL]ClientConfig
 // later we will need another constructor that would request installations and create pool from it
-func NewClientPoolFromTokens(urlToConfig map[string]ClientConfig, defaultConfig ClientConfig, cache *cache.ValidableCache) (*ClientPool, error) {
+func NewClientPoolFromTokens(urlToConfig map[string]ClientConfig, cache *cache.ValidableCache) (*ClientPool, error) {
 	byConfig := make(map[ClientConfig][]*lookout.RepositoryInfo)
 
 	for url, c := range urlToConfig {
 		repo, err := vcsurl.Parse(url)
 		if err != nil {
 			return nil, err
-		}
-
-		if c.IsZero() {
-			c = defaultConfig
 		}
 
 		byConfig[c] = append(byConfig[c], repo)

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -16,10 +16,10 @@ type ClientConfig struct {
 	MinInterval string
 }
 
-var zeroClientConfig = &ClientConfig{}
+var zeroClientConfig = ClientConfig{}
 
 // IsZero return true if config is empty and false otherwise
-func (c *ClientConfig) IsZero() bool {
+func (c ClientConfig) IsZero() bool {
 	return c == zeroClientConfig
 }
 


### PR DESCRIPTION
Fix #157.

The bug was checking zero value with 2 pointers, instead of values.
I also moved the default auth management to `serve.go`, I think it simplifies it and make it easier to understanding.