### PR TITLE
Add Drone CD config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,81 @@
+workspace:
+  base: /go
+  path: src/github.com/src-d/lookout
+
+branches: [master]
+
+# ANCHORS
+
+build: &build
+  image: golang:1.10-stretch
+  commands:
+    - make dependencies
+    - PKG_OS=linux DOCKER_OS=linux DOCKER_ARCH=amd64 make packages
+  debug: true
+
+docker_image: &docker_image
+  group: docker
+  image: plugins/docker
+  registry: docker.io
+  repo: srcd/lookout
+  secrets: [ docker_username, docker_password ]
+  dockerfile: Dockerfile
+  debug: true
+
+helm_deploy: &helm_deploy
+  image: quay.io/ipedrazas/drone-helm:master-9b37211
+  skip_tls_verify: true
+  helm_repos: srcd-charts=https://src-d.github.io/charts/
+  chart: srcd-charts/lookout
+  release: gp
+  tiller_ns: kube-system
+  wait: true
+
+# PIPELINE STEPS
+
+pipeline:
+
+  clone:
+    image: plugins/git
+    debug: true
+
+  # deployment to staging environment when master is pushed
+
+  build_stg:
+    <<: *build
+    when:
+      branch: [master]
+      event: [push]
+
+  docker_image_stg:
+    <<: *docker_image
+    # workaround for bug https://github.com/kubernetes/helm/issues/1707
+    tag: 'commit-${DRONE_COMMIT_SHA:0:7}'
+    when:
+      branch: [master]
+      event: [push]
+
+  helm_deploy_stg:
+    <<: *helm_deploy
+    prefix: STG
+    secrets: [ STG_API_SERVER, STG_KUBERNETES_TOKEN ]
+    values: image.lookout.tag=commit-${DRONE_COMMIT_SHA:0:7}
+    values_files: [.helm-staging.yml]
+    when:
+      branch: [master]
+      event: [push]
+
+  # Push to DockerHub when a new tag is created
+
+  build_release:
+    <<: *build
+    when:
+      event: [tag]
+
+  docker_image_release:
+    <<: *docker_image
+    tags:
+      - '${DRONE_TAG}'
+      - 'latest'
+    when:
+      event: [tag]

--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -1,0 +1,19 @@
+app:
+  lookout:
+    repository: github.com/src-d/lookout
+    logLevel: debug
+    secretName: lookout-github-credentials
+    dbConnectionString: postgres://lookout:lookout@lookout-postgresql:5432/lookout?sslmode=disable
+    bblfshdConnectionString: ipv4://lookout-bblfshd-bblfshd:9432
+
+nodeSelector:
+ lookout:
+   srcd.host/type: worker
+
+nodeSelector:
+ dummyAnalyzer:
+   srcd.host/type: worker
+
+providers:
+  github:
+    comment_footer: "_If you have feedback about this comment, please, [tell us](%s)._"

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,11 +101,6 @@ jobs:
       before_install: skip
       script: PKG_OS="darwin" make packages-sdk
       deploy: *deploy_anchor
-    - name: "push image to Docker Hub"
-      stage: release
-      script:
-        - PKG_OS=linux make build
-        - DOCKER_PUSH_LATEST=true make docker-push
     - name: "push dummy analyzer image to Docker Hub"
       stage: release dummy analyzer
       script:


### PR DESCRIPTION
Fix #160.
Depends on https://github.com/src-d/charts/pull/63.

Question for @rporres: how do we configure the github username and token? do we need to config these secrets somewhere in `.drone.yml` or `.helm-staging.yml`?

Based on the drone config we use for gitbase-web, staging would be updated with each new commit in master.
The only reason I've moved the docker hub upload from travis to drone is for consistency with gitbase-web.