### PR TITLE
SDK CLI: add relevant logs

### DIFF
--- a/cmd/lookout/event.go
+++ b/cmd/lookout/event.go
@@ -46,6 +46,7 @@ func (c *EventCommand) openRepository() error {
 }
 
 func (c *EventCommand) resolveRefs() (*lookout.ReferencePointer, *lookout.ReferencePointer, error) {
+	log.Infof("Resolving to/from references")
 	baseHash, err := getCommitHashByRev(c.repo, c.RevFrom)
 	if err != nil {
 		return nil, nil, fmt.Errorf("base revision error: %s", err)
@@ -118,6 +119,7 @@ func (c *EventCommand) makeDataServerHandler() (*lookout.DataServerHandler, erro
 }
 
 func (c *EventCommand) bindDataServer(srv *lookout.DataServerHandler, serveResult chan error) (*grpc.Server, error) {
+	log.Infof("starging a DataServer at %s", c.DataServer)
 	grpcSrv := grpchelper.NewServer()
 	lookout.RegisterDataServer(grpcSrv, srv)
 
@@ -133,6 +135,7 @@ func (c *EventCommand) bindDataServer(srv *lookout.DataServerHandler, serveResul
 
 func (c *EventCommand) analyzerClient() (lookout.AnalyzerClient, error) {
 	var err error
+	log.Infof("start looking for Analyzer at %s", c.Args.Analyzer)
 
 	grpcAddr, err := grpchelper.ToGoGrpcAddress(c.Args.Analyzer)
 	if err != nil {

--- a/cmd/lookout/event.go
+++ b/cmd/lookout/event.go
@@ -46,7 +46,7 @@ func (c *EventCommand) openRepository() error {
 }
 
 func (c *EventCommand) resolveRefs() (*lookout.ReferencePointer, *lookout.ReferencePointer, error) {
-	log.Infof("Resolving to/from references")
+	log.Infof("resolving to/from references")
 	baseHash, err := getCommitHashByRev(c.repo, c.RevFrom)
 	if err != nil {
 		return nil, nil, fmt.Errorf("base revision error: %s", err)
@@ -119,7 +119,7 @@ func (c *EventCommand) makeDataServerHandler() (*lookout.DataServerHandler, erro
 }
 
 func (c *EventCommand) bindDataServer(srv *lookout.DataServerHandler, serveResult chan error) (*grpc.Server, error) {
-	log.Infof("starging a DataServer at %s", c.DataServer)
+	log.Infof("starting a DataServer at %s", c.DataServer)
 	grpcSrv := grpchelper.NewServer()
 	lookout.RegisterDataServer(grpcSrv, srv)
 
@@ -135,7 +135,7 @@ func (c *EventCommand) bindDataServer(srv *lookout.DataServerHandler, serveResul
 
 func (c *EventCommand) analyzerClient() (lookout.AnalyzerClient, error) {
 	var err error
-	log.Infof("start looking for Analyzer at %s", c.Args.Analyzer)
+	log.Infof("starting looking for Analyzer at %s", c.Args.Analyzer)
 
 	grpcAddr, err := grpchelper.ToGoGrpcAddress(c.Args.Analyzer)
 	if err != nil {

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -62,7 +62,7 @@ func (s *Syncer) fetch(ctx context.Context, repoURL string, r *git.Repository, r
 		if err == nil {
 			ctxlog.Get(ctx).
 				With(log.Fields{"duration": time.Now().Sub(start)}).
-				Debugf("references %v fetched for repository %s", repoURL, refspecs)
+				Debugf("references %v fetched for repository %s", refspecs, repoURL)
 		}
 		// in case of error it will be logged on upper level
 	}()


### PR DESCRIPTION
While developing/debugging a new analyzer I found these logs were super helpful in SDK binary.
