### PR TITLE
Use fixed revisions for integration tests

### DIFF
--- a/cmd/sdk-test/bblfsh_test.go
+++ b/cmd/sdk-test/bblfsh_test.go
@@ -27,7 +27,10 @@ func (suite *BblfshIntegrationSuite) TearDownSuite() {
 }
 
 func (suite *BblfshIntegrationSuite) TestNoBblfshError() {
-	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302", "--bblfshd=ipv4://localhost:0000")
+	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
+		"--bblfshd=ipv4://localhost:0000",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
 	cmdtest.GrepTrue(r, "WantUAST isn't allowed")
 }
 

--- a/cmd/sdk-test/dummy_test.go
+++ b/cmd/sdk-test/dummy_test.go
@@ -27,12 +27,16 @@ func (suite *IntegrationSuite) TearDownSuite() {
 }
 
 func (suite *IntegrationSuite) TestReview() {
-	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302")
+	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
 	cmdtest.GrepTrue(r, "posting analysis")
 }
 
 func (suite *IntegrationSuite) TestPush() {
-	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302")
+	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
 	cmdtest.GrepTrue(r, "dummy comment for push event")
 }
 


### PR DESCRIPTION
Integration tests are failing erratically, and I realized some SDK tests use default revisions, HEAD and HEAD^. This means that sometimes the dummy analyzer returns 0 comments, and the tests fail.