### PR TITLE
Tests for GetFiles language

### DIFF
--- a/cmd/dummy/main.go
+++ b/cmd/dummy/main.go
@@ -18,9 +18,10 @@ var (
 
 type ServeCommand struct {
 	cli.CommonOptions
-	Analyzer    string `long:"analyzer" default:"ipv4://localhost:10302" env:"LOOKOUT_ANALYZER" description:"gRPC URL to bind the analyzer to"`
-	DataServer  string `long:"data-server" default:"ipv4://localhost:10301" env:"LOOKOUT_DATA_SERVER" description:"gRPC URL of the data server"`
-	RequestUAST bool   `long:"uast" env:"LOOKOUT_REQUEST_UAST" description:"analyzer will request UAST from the data server"`
+	Analyzer         string `long:"analyzer" default:"ipv4://localhost:10302" env:"LOOKOUT_ANALYZER" description:"gRPC URL to bind the analyzer to"`
+	DataServer       string `long:"data-server" default:"ipv4://localhost:10301" env:"LOOKOUT_DATA_SERVER" description:"gRPC URL of the data server"`
+	RequestUAST      bool   `long:"uast" env:"LOOKOUT_REQUEST_UAST" description:"analyzer will request UAST from the data server"`
+	RequestFilesPush bool   `long:"files" env:"LOOKOUT_REQUEST_FILES" description:"on push events the analyzer will request files from HEAD, and return comments"`
 }
 
 func (c *ServeCommand) Execute(args []string) error {
@@ -41,9 +42,10 @@ func (c *ServeCommand) Execute(args []string) error {
 	}
 
 	a := &dummy.Analyzer{
-		Version:     version,
-		DataClient:  lookout.NewDataClient(conn),
-		RequestUAST: c.RequestUAST,
+		Version:          version,
+		DataClient:       lookout.NewDataClient(conn),
+		RequestUAST:      c.RequestUAST,
+		RequestFilesPush: c.RequestFilesPush,
 	}
 
 	server := grpchelper.NewServer()

--- a/cmd/sdk-test/bblfsh_test.go
+++ b/cmd/sdk-test/bblfsh_test.go
@@ -27,7 +27,10 @@ func (suite *BblfshIntegrationSuite) TearDownSuite() {
 }
 
 func (suite *BblfshIntegrationSuite) TestNoBblfshError() {
-	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302", "--bblfshd=ipv4://localhost:0000")
+	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
+		"--bblfshd=ipv4://localhost:0000",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
 	cmdtest.GrepTrue(r, "WantUAST isn't allowed")
 }
 

--- a/cmd/sdk-test/bblfsh_test.go
+++ b/cmd/sdk-test/bblfsh_test.go
@@ -4,6 +4,7 @@ package sdk_test
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/src-d/lookout/util/cmdtest"
@@ -19,14 +20,26 @@ type BblfshIntegrationSuite struct {
 
 func (suite *BblfshIntegrationSuite) SetupSuite() {
 	suite.ctx, suite.stop = cmdtest.StoppableCtx()
-	cmdtest.StartDummy(suite.ctx, "--uast")
+	cmdtest.StartDummy(suite.ctx, "--uast", "--files")
 }
 
 func (suite *BblfshIntegrationSuite) TearDownSuite() {
 	suite.stop()
 }
 
-func (suite *BblfshIntegrationSuite) TestNoBblfshError() {
+func (suite *BblfshIntegrationSuite) RunReview() io.Reader {
+	return cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
+}
+
+func (suite *BblfshIntegrationSuite) RunPush() io.Reader {
+	return cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
+}
+
+func (suite *BblfshIntegrationSuite) TestReviewNoBblfshError() {
 	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
 		"--bblfshd=ipv4://localhost:0000",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
@@ -34,11 +47,42 @@ func (suite *BblfshIntegrationSuite) TestNoBblfshError() {
 	cmdtest.GrepTrue(r, "WantUAST isn't allowed")
 }
 
-func (suite *BblfshIntegrationSuite) TestNoUASTWarning() {
-	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
+func (suite *BblfshIntegrationSuite) TestReviewNoUASTWarning() {
+	r := suite.RunReview()
+	cmdtest.GrepTrue(r, "The file doesn't have UAST")
+}
+
+func (suite *BblfshIntegrationSuite) TestReviewUAST() {
+	r := suite.RunReview()
+	cmdtest.GrepTrue(r, "The file has UAST.")
+}
+
+func (suite *BblfshIntegrationSuite) TestReviewLanguage() {
+	r := suite.RunReview()
+	cmdtest.GrepTrue(r, `The file has language detected: "Go"`)
+}
+
+func (suite *BblfshIntegrationSuite) TestPushNoBblfshError() {
+	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302",
+		"--bblfshd=ipv4://localhost:0000",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
+	cmdtest.GrepTrue(r, "WantUAST isn't allowed")
+}
+
+func (suite *BblfshIntegrationSuite) TestPushNoUASTWarning() {
+	r := suite.RunPush()
 	cmdtest.GrepTrue(r, "The file doesn't have UAST")
+}
+
+func (suite *BblfshIntegrationSuite) TestPushUAST() {
+	r := suite.RunPush()
+	cmdtest.GrepTrue(r, "The file has UAST.")
+}
+
+func (suite *BblfshIntegrationSuite) TestPushLanguage() {
+	r := suite.RunPush()
+	cmdtest.GrepTrue(r, `The file has language detected: "Go"`)
 }
 
 func TestBblfshIntegrationSuite(t *testing.T) {

--- a/cmd/sdk-test/dummy_test.go
+++ b/cmd/sdk-test/dummy_test.go
@@ -27,12 +27,16 @@ func (suite *IntegrationSuite) TearDownSuite() {
 }
 
 func (suite *IntegrationSuite) TestReview() {
-	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302")
+	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
 	cmdtest.GrepTrue(r, "posting analysis")
 }
 
 func (suite *IntegrationSuite) TestPush() {
-	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302")
+	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
 	cmdtest.GrepTrue(r, "dummy comment for push event")
 }
 

--- a/cmd/sdk-test/dummy_test.go
+++ b/cmd/sdk-test/dummy_test.go
@@ -17,16 +17,17 @@ type IntegrationSuite struct {
 	stop func()
 }
 
-func (suite *IntegrationSuite) SetupSuite() {
+func (suite *IntegrationSuite) SetupTest() {
 	suite.ctx, suite.stop = cmdtest.StoppableCtx()
-	cmdtest.StartDummy(suite.ctx)
 }
 
-func (suite *IntegrationSuite) TearDownSuite() {
+func (suite *IntegrationSuite) TearDownTest() {
 	suite.stop()
 }
 
 func (suite *IntegrationSuite) TestReview() {
+	cmdtest.StartDummy(suite.ctx, "--files")
+
 	r := cmdtest.RunCli(suite.ctx, "review", "ipv4://localhost:10302",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
@@ -34,10 +35,21 @@ func (suite *IntegrationSuite) TestReview() {
 }
 
 func (suite *IntegrationSuite) TestPush() {
+	cmdtest.StartDummy(suite.ctx, "--files")
+
 	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	cmdtest.GrepTrue(r, "dummy comment for push event")
+	cmdtest.GrepTrue(r, "posting analysis")
+}
+
+func (suite *IntegrationSuite) TestPushNoComments() {
+	cmdtest.StartDummy(suite.ctx)
+
+	r := cmdtest.RunCli(suite.ctx, "push", "ipv4://localhost:10302",
+		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
+		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
+	cmdtest.GrepTrue(r, "no comments were produced")
 }
 
 func TestIntegrationSuite(t *testing.T) {

--- a/cmd/server-test/main.go
+++ b/cmd/server-test/main.go
@@ -23,7 +23,7 @@ func main() {
 	cmdtest.ResetDB()
 
 	ctx, stop := cmdtest.StoppableCtx()
-	cmdtest.StartDummy(ctx)
+	cmdtest.StartDummy(ctx, "--files")
 	r, w := cmdtest.StartServe(ctx, "--provider", "json", "dummy-repo-url")
 
 	// make sure server started correctly
@@ -59,7 +59,6 @@ func main() {
 		successPushJSON := `{"event":"push", "internal_id": "1", "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"4eebef102d7979570aadf69ff54ae1ffcca7ce00"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"d304499cb2a9cad3ea260f06ad59c1658db4763d"}}}`
 		sendEvent(w, successPushJSON)
 		grepTrue(r, "processing push")
-		grepTrue(r, "comments can belong only to review event but 1 is given")
 		grepTrue(r, `status=success`)
 	})
 
@@ -68,8 +67,8 @@ func main() {
 	cmdtest.ResetDB()
 
 	ctx, stop = cmdtest.StoppableCtx()
-	cmdtest.StartDummy(ctx)
-	cmdtest.StartDummy(ctx, "--analyzer", "ipv4://localhost:10303")
+	cmdtest.StartDummy(ctx, "--files")
+	cmdtest.StartDummy(ctx, "--files", "--analyzer", "ipv4://localhost:10303")
 	r, w = cmdtest.StartServe(ctx, "--provider", "json", "-c", "fixtures/double_dummy_config.yml", "dummy-repo-url")
 
 	grepTrue(r, "Starting watcher")

--- a/cmd/server-test/main.go
+++ b/cmd/server-test/main.go
@@ -29,11 +29,11 @@ func main() {
 	// make sure server started correctly
 	grepTrue(r, "Starting watcher")
 
-	successJSON := `{"event":"review", "internal_id": "1", "number": 1, "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"4eebef102d7979570aadf69ff54ae1ffcca7ce00"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"d304499cb2a9cad3ea260f06ad59c1658db4763d"}}}`
+	successJSON := `{"event":"review", "internal_id": "1", "number": 1, "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"66924f49aa9987273a137857c979ee5f0e709e30"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"2c9f56bcb55be47cf35d40d024ec755399f699c7"}}}`
 	testCase("success review", func() {
 		sendEvent(w, successJSON)
 		grepTrue(r, "processing pull request")
-		grepTrue(r, `{"analyzer-name":"Dummy","file":"provider/common.go","text":"The file has increased in 5 lines."}`)
+		grepTrue(r, `{"analyzer-name":"Dummy","file":"cmd/lookout/push.go","line":13,"text":"This line exceeded 80 bytes."}`)
 		grepTrue(r, `status=success`)
 	})
 
@@ -43,7 +43,7 @@ func main() {
 	})
 
 	testCase("process review but don't post anything", func() {
-		json := `{"event":"review", "internal_id": "2", "number": 1, "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"4eebef102d7979570aadf69ff54ae1ffcca7ce00"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"d304499cb2a9cad3ea260f06ad59c1658db4763d"}}}`
+		json := `{"event":"review", "internal_id": "2", "number": 1, "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"66924f49aa9987273a137857c979ee5f0e709e30"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"2c9f56bcb55be47cf35d40d024ec755399f699c7"}}}`
 		sendEvent(w, json)
 		grepTrue(r, "processing pull request")
 		grepAndNot(r, `status=success`, `posting analysis`)
@@ -56,9 +56,10 @@ func main() {
 	})
 
 	testCase("success push", func() {
-		successPushJSON := `{"event":"push", "internal_id": "1", "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"4eebef102d7979570aadf69ff54ae1ffcca7ce00"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"d304499cb2a9cad3ea260f06ad59c1658db4763d"}}}`
+		successPushJSON := `{"event":"push", "internal_id": "1", "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"66924f49aa9987273a137857c979ee5f0e709e30"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"2c9f56bcb55be47cf35d40d024ec755399f699c7"}}}`
 		sendEvent(w, successPushJSON)
 		grepTrue(r, "processing push")
+		grepTrue(r, "comments can belong only to review event but 1 is given")
 		grepTrue(r, `status=success`)
 	})
 
@@ -85,14 +86,16 @@ func main() {
 		}
 		if !strings.Contains(
 			buf.String(),
-			`{"analyzer-name":"Dummy1","file":"provider/common.go","text":"The file has increased in 5 lines."}`) {
+			`{"analyzer-name":"Dummy1","file":"cmd/lookout/push.go","line":13,"text":"This line exceeded 80 bytes."}`) {
+
 			fmt.Println("no comments from the first analyzer")
 			stop()
 			os.Exit(1)
 		}
 		if !strings.Contains(
 			buf.String(),
-			`{"analyzer-name":"Dummy2","file":"provider/common.go","text":"The file has increased in 5 lines."}`) {
+			`{"analyzer-name":"Dummy2","file":"cmd/lookout/push.go","line":13,"text":"This line exceeded 80 bytes."}`) {
+
 			fmt.Println("no comments from the second analyzer")
 			stop()
 			os.Exit(1)

--- a/dummy/dummy_test.go
+++ b/dummy/dummy_test.go
@@ -48,6 +48,7 @@ func (s *DummySuite) SetupSuite() {
 	s.apiServer = grpc.NewServer()
 	server := &lookout.DataServerHandler{
 		ChangeGetter: git.NewService(&git.StorerCommitLoader{sto}),
+		FileGetter:   git.NewService(&git.StorerCommitLoader{sto}),
 	}
 	lookout.RegisterDataServer(s.apiServer, server)
 
@@ -86,7 +87,8 @@ func (s *DummySuite) Test() {
 	require := s.Require()
 
 	a := &Analyzer{
-		DataClient: s.apiClient,
+		DataClient:       s.apiClient,
+		RequestFilesPush: true,
 	}
 
 	s.analyzerServer = grpc.NewServer()


### PR DESCRIPTION
Tests for #176.

The changes are:
**fixed revisions**: Integration tests are failing erratically, and I realized some SDK tests use default revisions, HEAD and HEAD^. This means that sometimes the dummy analyzer returns 0 comments, and the tests fail.
**don't return comments for push events**: The dummy analyzer was returning one fixed comment for each push event, but this is not expected by the server, and we had lots of errors in the logs. Now the dummy analyzer accepts `--files`. When it's enabled, we call `GetFiles` (we were only testing `GetChanges` before), and return comments similar to the ones in the review event.
**add comments about uast & language**: if `--uast` is used, there are comments informing of the response uast and file language