### PR TITLE
Git: check for empty values in received ReferencePointers

### DIFF
--- a/cmd/lookout/event.go
+++ b/cmd/lookout/event.go
@@ -64,13 +64,13 @@ func (c *EventCommand) resolveRefs() (*lookout.ReferencePointer, *lookout.Refere
 
 	fromRef := lookout.ReferencePointer{
 		InternalRepositoryURL: "file://" + fullGitPath,
-		ReferenceName:         plumbing.ReferenceName(c.RevFrom),
+		ReferenceName:         plumbing.HEAD,
 		Hash:                  baseHash,
 	}
 
 	toRef := lookout.ReferencePointer{
 		InternalRepositoryURL: "file://" + fullGitPath,
-		ReferenceName:         plumbing.ReferenceName(c.RevTo),
+		ReferenceName:         plumbing.HEAD,
 		Hash:                  headHash,
 	}
 

--- a/dummy/dummy_test.go
+++ b/dummy/dummy_test.go
@@ -111,11 +111,13 @@ func (s *DummySuite) Test() {
 		CommitRevision: lookout.CommitRevision{
 			Base: lookout.ReferencePointer{
 				InternalRepositoryURL: "file:///fixture/basic",
-				Hash: "918c48b83bd081e863dbe1b80f8998f058cd8294",
+				ReferenceName:         "notUsedInTestsButValidated",
+				Hash:                  "918c48b83bd081e863dbe1b80f8998f058cd8294",
 			},
 			Head: lookout.ReferencePointer{
 				InternalRepositoryURL: "file:///fixture/basic",
-				Hash: s.Basic.Head.String(),
+				ReferenceName:         "notUsedInTestsButValidated",
+				Hash:                  s.Basic.Head.String(),
 			},
 		},
 	})
@@ -126,11 +128,13 @@ func (s *DummySuite) Test() {
 		CommitRevision: lookout.CommitRevision{
 			Base: lookout.ReferencePointer{
 				InternalRepositoryURL: "file:///fixture/basic",
-				Hash: "918c48b83bd081e863dbe1b80f8998f058cd8294",
+				ReferenceName:         "notUsedInTestsButValidated",
+				Hash:                  "918c48b83bd081e863dbe1b80f8998f058cd8294",
 			},
 			Head: lookout.ReferencePointer{
 				InternalRepositoryURL: "file:///fixture/basic",
-				Hash: s.Basic.Head.String(),
+				ReferenceName:         "notUsedInTestsButValidated",
+				Hash:                  s.Basic.Head.String(),
 			},
 		},
 	})

--- a/service/git/examples_test.go
+++ b/service/git/examples_test.go
@@ -30,11 +30,13 @@ func Example() {
 		&lookout.ChangesRequest{
 			Base: &lookout.ReferencePointer{
 				InternalRepositoryURL: "file:///myrepo",
-				Hash: "af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+				ReferenceName:         "notUsedInTestsButValidated",
+				Hash:                  "af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
 			},
 			Head: &lookout.ReferencePointer{
 				InternalRepositoryURL: "file:///myrepo",
-				Hash: "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+				ReferenceName:         "notUsedInTestsButValidated",
+				Hash:                  "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
 			},
 		})
 	if err != nil {


### PR DESCRIPTION
This fixes current style-analyzer failure mode on staging:

```
{"app":"lookout","level":"debug","msg":"load trees for references: [{git://github.com/bblfsh/uast-viewer.git  07c123ff0bdbe7bd87f03c4d98f95d4ff2ec0df1}]","source":"git/service.go:103","time":"2018-08-24T18:01:04.635128964Z"}
{"app":"lookout","level":"info","msg":"fetching references for repository git://github.com/bblfsh/uast-viewer.git: [:]","source":"git/syncer.go:59","time":"2018-08-24T18:01:04.63538259Z"}
{"app":"lookout","duration":496267539,"error":"malformed refspec, separators are wrong","grpc.code":2,"grpc.method":"GetFiles","grpc.service":"pb.Data","grpc.start_time":"2018-08-24T18:01:04Z","level":"info","msg":"streaming server call finished","source":"grpchelper/logger.go:19","span.kind":"server","system":"grpc","time":"2018-08-24T18:01:05.131271264Z"}
```

It validates user input for `GetFiles` and `GetChanges` in the DataService, before passing it in to any of the LibraryCommitLoader or StorerCommitLoader.

Was not reproducible locally \w SDK+style-analyzer, as SDK binary only uses StorerCommitLoader that does not use Syncer to fetch.

Current behavior allows `GetFiles` request with empty ReferenceName in Revision, by explicitly [falling back to the default RefSpec](https://github.com/src-d/lookout/pull/193/files#diff-6bd7698193142bec9f5cd80af5f41970R53), before fetching.

`GetChanges` without ReferenceNames in Head or Base are prohibited as it's expected to be used on PRs.

Test plan:
 - `go test ./service/git`

