### PR TITLE
Make dummy analyzer less annoying

### DIFF
--- a/cmd/server-test/dummy_analyzer_test.go
+++ b/cmd/server-test/dummy_analyzer_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const dummyConfigFile = "../../fixtures/dummy_config.yml"
+
 type DummyIntegrationSuite struct {
 	IntegrationSuite
 }
@@ -20,7 +22,7 @@ func (suite *DummyIntegrationSuite) SetupTest() {
 	suite.StoppableCtx()
 	suite.StartDummy("--files")
 	suite.r, suite.w = suite.StartServe("--provider", "json",
-		"-c", "../../fixtures/dummy_config.yml", "dummy-repo-url")
+		"-c", dummyConfigFile, "dummy-repo-url")
 
 	// make sure server started correctly
 	cmdtest.GrepTrue(suite.r, "Starting watcher")
@@ -35,7 +37,7 @@ const successJSON = `{"event":"review", "internal_id": "1", "number": 1, "commit
 func (suite *DummyIntegrationSuite) TestSuccessReview() {
 	suite.sendEvent(successJSON)
 	cmdtest.GrepTrue(suite.r, "processing pull request")
-	cmdtest.GrepTrue(suite.r, `{"analyzer-name":"Dummy","file":"cmd/lookout/push.go","line":13,"text":"This line exceeded 80 bytes."}`)
+	cmdtest.GrepTrue(suite.r, `{"analyzer-name":"Dummy","file":"cmd/lookout/serve.go","line":33,"text":"This line exceeded`)
 	cmdtest.GrepTrue(suite.r, `status=success`)
 }
 

--- a/cmd/server-test/multi_analyzer_test.go
+++ b/cmd/server-test/multi_analyzer_test.go
@@ -3,12 +3,15 @@
 package server_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/src-d/lookout/util/cmdtest"
 
 	"github.com/stretchr/testify/suite"
 )
+
+const dubleDummyConfigFile = "../../fixtures/double_dummy_config.yml"
 
 type MultiDummyIntegrationSuite struct {
 	IntegrationSuite
@@ -21,7 +24,7 @@ func (suite *MultiDummyIntegrationSuite) SetupTest() {
 	suite.StartDummy("--files")
 	suite.StartDummy("--files", "--analyzer", "ipv4://localhost:10303")
 	suite.r, suite.w = suite.StartServe("--provider", "json",
-		"-c", "../../fixtures/double_dummy_config.yml", "dummy-repo-url")
+		"-c", dubleDummyConfigFile, "dummy-repo-url")
 
 	// make sure server started correctly
 	cmdtest.GrepTrue(suite.r, "Starting watcher")
@@ -42,13 +45,15 @@ func (suite *MultiDummyIntegrationSuite) TestSuccessReview() {
 
 	suite.Require().Contains(
 		st,
-		`{"analyzer-name":"Dummy1","file":"cmd/lookout/push.go","line":13,"text":"This line exceeded 80 bytes."}`,
-		"no comments from the first analyzer")
+		`{"analyzer-name":"Dummy1","file":"cmd/lookout/serve.go","line":33,"text":"This line exceeded`,
+		fmt.Sprintf("no comments from the first analyzer from %s in '%s'", dubleDummyConfigFile, buf),
+	)
 
 	suite.Require().Contains(
 		st,
-		`{"analyzer-name":"Dummy2","file":"cmd/lookout/push.go","line":13,"text":"This line exceeded 80 bytes."}`,
-		"no comments from the second analyzer")
+		`{"analyzer-name":"Dummy2","file":"cmd/lookout/serve.go","line":33,"text":"This line exceeded`,
+		fmt.Sprintf("no comments from the second analyzer from %s in '%s'", dubleDummyConfigFile, buf),
+	)
 }
 
 func TestMultiDummyIntegrationSuite(t *testing.T) {

--- a/dummy/dummy.go
+++ b/dummy/dummy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/src-d/lookout"
 
@@ -106,14 +107,14 @@ func (a *Analyzer) maxLineLen(file *lookout.File) []*lookout.Comment {
 		return nil
 	}
 
-	lines := bytes.Split(file.Content, []byte("\n"))
+	lines := strings.Split(string(file.Content), "\n")
 	var comments []*lookout.Comment
 	for i, line := range lines {
 		if len(line) > maxLineLength {
 			comments = append(comments, &lookout.Comment{
 				File: file.Path,
 				Line: int32(i + 1),
-				Text: fmt.Sprintf("This line exceeded %d bytes.", maxLineLength),
+				Text: fmt.Sprintf("This line exceeded %d chars.", maxLineLength),
 			})
 		}
 	}


### PR DESCRIPTION
Change it to report only `len(line) > 120` for non-binary files.