### PR TITLE
Move docker release back to Travis

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -63,18 +63,3 @@ pipeline:
     when:
       branch: [master]
       event: [push]
-
-  # Push to DockerHub when a new tag is created
-
-  build_release:
-    <<: *build
-    when:
-      event: [tag]
-
-  docker_image_release:
-    <<: *docker_image
-    tags:
-      - '${DRONE_TAG}'
-      - 'latest'
-    when:
-      event: [tag]

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,11 @@ jobs:
       before_install: skip
       script: PKG_OS="darwin" make packages-sdk
       deploy: *deploy_anchor
+    - name: "push image to Docker Hub"
+      stage: release
+      script:
+        - PKG_OS=linux make build
+        - DOCKER_PUSH_LATEST=true make docker-push
     - name: "push dummy analyzer image to Docker Hub"
       stage: release dummy analyzer
       script:


### PR DESCRIPTION
Fix #189.

I didn't see how to filter by tag name in the [drone docs](http://docs.drone.io/step-conditions/), so I moved the release back to travis. Which we kept using for the dummy analyzer docker images, so it makes sense to do everything there.
 
With this PR travis releases docker images on tag (latest and tag-name), and drone for each commit (commit-sha1).