### PR TITLE
Add feedback links to analyzers config on staging

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -21,5 +21,7 @@ providers:
 analyzers:
   - name: style-analyzer
     addr: ipv4://lookout-style-analyzer:2000
+    feedback: https://github.com/src-d/style-analyzer/issues/new
   - name: gometalint-analyzer
     addr: ipv4://lookout-gometalint-analyzer:10303
+    feedback: https://github.com/src-d/lookout-gometalint-analyzer/issues/new


### PR DESCRIPTION
So there is a way for a user to provide the feedback to each analyzer.