### PR TITLE
Fix GrepTrue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 services:
   - docker
 
+git:
+  depth: false
+
 addons:
   apt:
     sources:

--- a/cmd/sdk-test/bblfsh_test.go
+++ b/cmd/sdk-test/bblfsh_test.go
@@ -41,22 +41,22 @@ func (suite *BblfshIntegrationSuite) TestReviewNoBblfshError() {
 		"--bblfshd=ipv4://localhost:0000",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	cmdtest.GrepTrue(r, "WantUAST isn't allowed")
+	suite.GrepTrue(r, "WantUAST isn't allowed")
 }
 
 func (suite *BblfshIntegrationSuite) TestReviewNoUASTWarning() {
 	r := suite.RunReview()
-	cmdtest.GrepTrue(r, "The file doesn't have UAST")
+	suite.GrepTrue(r, "The file doesn't have UAST")
 }
 
 func (suite *BblfshIntegrationSuite) TestReviewUAST() {
 	r := suite.RunReview()
-	cmdtest.GrepTrue(r, "The file has UAST.")
+	suite.GrepTrue(r, "The file has UAST.")
 }
 
 func (suite *BblfshIntegrationSuite) TestReviewLanguage() {
 	r := suite.RunReview()
-	cmdtest.GrepTrue(r, `The file has language detected: "Go"`)
+	suite.GrepTrue(r, `The file has language detected: "Go"`)
 }
 
 func (suite *BblfshIntegrationSuite) TestPushNoBblfshError() {
@@ -64,22 +64,22 @@ func (suite *BblfshIntegrationSuite) TestPushNoBblfshError() {
 		"--bblfshd=ipv4://localhost:0000",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	cmdtest.GrepTrue(r, "WantUAST isn't allowed")
+	suite.GrepTrue(r, "WantUAST isn't allowed")
 }
 
 func (suite *BblfshIntegrationSuite) TestPushNoUASTWarning() {
 	r := suite.RunPush()
-	cmdtest.GrepTrue(r, "The file doesn't have UAST")
+	suite.GrepTrue(r, "The file doesn't have UAST")
 }
 
 func (suite *BblfshIntegrationSuite) TestPushUAST() {
 	r := suite.RunPush()
-	cmdtest.GrepTrue(r, "The file has UAST.")
+	suite.GrepTrue(r, "The file has UAST.")
 }
 
 func (suite *BblfshIntegrationSuite) TestPushLanguage() {
 	r := suite.RunPush()
-	cmdtest.GrepTrue(r, `The file has language detected: "Go"`)
+	suite.GrepTrue(r, `The file has language detected: "Go"`)
 }
 
 func TestBblfshIntegrationSuite(t *testing.T) {

--- a/cmd/sdk-test/dummy_test.go
+++ b/cmd/sdk-test/dummy_test.go
@@ -28,7 +28,7 @@ func (suite *SDKDummyTestSuite) TestReview() {
 	r := suite.RunCli("review", "ipv4://localhost:10302",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	cmdtest.GrepTrue(r, "posting analysis")
+	suite.GrepTrue(r, "posting analysis")
 }
 
 func (suite *SDKDummyTestSuite) TestPush() {
@@ -37,7 +37,7 @@ func (suite *SDKDummyTestSuite) TestPush() {
 	r := suite.RunCli("push", "ipv4://localhost:10302",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	cmdtest.GrepTrue(r, "posting analysis")
+	suite.GrepTrue(r, "posting analysis")
 }
 
 func (suite *SDKDummyTestSuite) TestPushNoComments() {
@@ -46,7 +46,7 @@ func (suite *SDKDummyTestSuite) TestPushNoComments() {
 	r := suite.RunCli("push", "ipv4://localhost:10302",
 		"--from=66924f49aa9987273a137857c979ee5f0e709e30",
 		"--to=2c9f56bcb55be47cf35d40d024ec755399f699c7")
-	cmdtest.GrepTrue(r, "no comments were produced")
+	suite.GrepTrue(r, "no comments were produced")
 }
 
 func TestSDKDummyTestSuite(t *testing.T) {

--- a/cmd/server-test/dummy_analyzer_test.go
+++ b/cmd/server-test/dummy_analyzer_test.go
@@ -5,8 +5,6 @@ package server_test
 import (
 	"testing"
 
-	"github.com/src-d/lookout/util/cmdtest"
-
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,7 +23,7 @@ func (suite *DummyIntegrationSuite) SetupTest() {
 		"-c", dummyConfigFile, "dummy-repo-url")
 
 	// make sure server started correctly
-	cmdtest.GrepTrue(suite.r, "Starting watcher")
+	suite.GrepTrue(suite.r, "Starting watcher")
 }
 
 func (suite *DummyIntegrationSuite) TearDownTest() {
@@ -36,41 +34,41 @@ const successJSON = `{"event":"review", "internal_id": "1", "number": 1, "commit
 
 func (suite *DummyIntegrationSuite) TestSuccessReview() {
 	suite.sendEvent(successJSON)
-	cmdtest.GrepTrue(suite.r, "processing pull request")
-	cmdtest.GrepTrue(suite.r, `{"analyzer-name":"Dummy","file":"cmd/lookout/serve.go","line":33,"text":"This line exceeded`)
-	cmdtest.GrepTrue(suite.r, `status=success`)
+	suite.GrepTrue(suite.r, "processing pull request")
+	suite.GrepTrue(suite.r, `{"analyzer-name":"Dummy","file":"cmd/lookout/serve.go","line":33,"text":"This line exceeded`)
+	suite.GrepTrue(suite.r, `status=success`)
 }
 
 func (suite *DummyIntegrationSuite) TestSkipReview() {
 	suite.sendEvent(successJSON)
-	cmdtest.GrepTrue(suite.r, `status=success`)
+	suite.GrepTrue(suite.r, `status=success`)
 
 	suite.sendEvent(successJSON)
-	cmdtest.GrepTrue(suite.r, `event successfully processed, skipping...`)
+	suite.GrepTrue(suite.r, `event successfully processed, skipping...`)
 }
 
 func (suite *DummyIntegrationSuite) TestReviewDontPost() {
 	suite.sendEvent(successJSON)
-	cmdtest.GrepTrue(suite.r, `status=success`)
+	suite.GrepTrue(suite.r, `status=success`)
 
 	json := `{"event":"review", "internal_id": "2", "number": 1, "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"66924f49aa9987273a137857c979ee5f0e709e30"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"2c9f56bcb55be47cf35d40d024ec755399f699c7"}}}`
 	suite.sendEvent(json)
-	cmdtest.GrepTrue(suite.r, "processing pull request")
-	cmdtest.GrepAndNot(suite.r, `status=success`, `posting analysis`)
+	suite.GrepTrue(suite.r, "processing pull request")
+	suite.GrepAndNot(suite.r, `status=success`, `posting analysis`)
 }
 
 func (suite *DummyIntegrationSuite) TestWrongRevision() {
 	json := `{"event":"review", "internal_id": "3", "number": 3, "commit_revision": {"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"0000000000000000000000000000000000000000"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"0000000000000000000000000000000000000000"}}}`
 	suite.sendEvent(json)
-	cmdtest.GrepTrue(suite.r, `event processing failed`)
+	suite.GrepTrue(suite.r, `event processing failed`)
 }
 
 func (suite *DummyIntegrationSuite) TestSuccessPush() {
 	successPushJSON := `{"event":"push", "internal_id": "1", "commit_revision":{"base":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"66924f49aa9987273a137857c979ee5f0e709e30"},"head":{"internal_repository_url":"https://github.com/src-d/lookout.git","reference_name":"refs/heads/master","hash":"2c9f56bcb55be47cf35d40d024ec755399f699c7"}}}`
 	suite.sendEvent(successPushJSON)
-	cmdtest.GrepTrue(suite.r, "processing push")
-	cmdtest.GrepTrue(suite.r, "comments can belong only to review event but 1 is given")
-	cmdtest.GrepTrue(suite.r, `status=success`)
+	suite.GrepTrue(suite.r, "processing push")
+	suite.GrepTrue(suite.r, "comments can belong only to review event but 1 is given")
+	suite.GrepTrue(suite.r, `status=success`)
 }
 
 func TestDummyIntegrationSuite(t *testing.T) {

--- a/cmd/server-test/error_analyzer_test.go
+++ b/cmd/server-test/error_analyzer_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/src-d/lookout"
-	"github.com/src-d/lookout/util/cmdtest"
 	"github.com/src-d/lookout/util/grpchelper"
 	log "gopkg.in/src-d/go-log.v1"
 
@@ -60,7 +59,7 @@ func (suite *ErrorAnalyzerIntegrationSuite) SetupTest() {
 		"-c", "../../fixtures/dummy_config.yml", "dummy-repo-url")
 
 	// make sure server started correctly
-	cmdtest.GrepTrue(suite.r, "Starting watcher")
+	suite.GrepTrue(suite.r, "Starting watcher")
 }
 
 func (suite *ErrorAnalyzerIntegrationSuite) TearDownTest() {
@@ -70,7 +69,7 @@ func (suite *ErrorAnalyzerIntegrationSuite) TearDownTest() {
 func (suite *ErrorAnalyzerIntegrationSuite) TestAnalyzerErr() {
 	suite.sendEvent(successJSON)
 
-	cmdtest.GrepTrue(suite.r, `msg="analysis failed" analyzer=Dummy app=lookout error="rpc error: code = Unknown desc = review error"`)
+	suite.GrepTrue(suite.r, `msg="analysis failed" analyzer=Dummy app=lookout error="rpc error: code = Unknown desc = review error"`)
 }
 
 func TestErrorAnalyzerIntegrationSuite(t *testing.T) {

--- a/cmd/server-test/multi_analyzer_test.go
+++ b/cmd/server-test/multi_analyzer_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/src-d/lookout/util/cmdtest"
-
 	"github.com/stretchr/testify/suite"
 )
 
@@ -27,7 +25,7 @@ func (suite *MultiDummyIntegrationSuite) SetupTest() {
 		"-c", dubleDummyConfigFile, "dummy-repo-url")
 
 	// make sure server started correctly
-	cmdtest.GrepTrue(suite.r, "Starting watcher")
+	suite.GrepTrue(suite.r, "Starting watcher")
 }
 
 func (suite *MultiDummyIntegrationSuite) TearDownTest() {
@@ -36,9 +34,9 @@ func (suite *MultiDummyIntegrationSuite) TearDownTest() {
 
 func (suite *MultiDummyIntegrationSuite) TestSuccessReview() {
 	suite.sendEvent(successJSON)
-	cmdtest.GrepTrue(suite.r, "processing pull request")
-	cmdtest.GrepTrue(suite.r, "posting analysis")
-	found, buf := cmdtest.Grep(suite.r, `status=success`)
+	suite.GrepTrue(suite.r, "processing pull request")
+	suite.GrepTrue(suite.r, "posting analysis")
+	found, buf := suite.Grep(suite.r, `status=success`)
 	suite.Require().Truef(found, "'%s' not found in:\n%s", `status=success`, buf.String())
 
 	st := buf.String()

--- a/util/cmdtest/cmds.go
+++ b/util/cmdtest/cmds.go
@@ -22,10 +22,6 @@ var CmdTimeout = time.Minute
 var dummyBin = "../../build/bin/dummy"
 var lookoutBin = "../../build/bin/lookout"
 
-// function to stop running commands
-// redefined in StoppableCtx
-var stop func()
-
 type IntegrationSuite struct {
 	suite.Suite
 	Ctx  context.Context
@@ -76,7 +72,8 @@ func (suite *IntegrationSuite) StartDummy(args ...string) io.Reader {
 				fmt.Println("analyzer exited with error:", err)
 				fmt.Printf("output:\n%s", buf.String())
 				// T.Fail cannot be called from a goroutine
-				failExit()
+				suite.Stop()
+				os.Exit(1)
 			}
 		}
 	}()
@@ -111,7 +108,8 @@ func (suite *IntegrationSuite) StartServe(args ...string) (io.Reader, io.WriteCl
 				fmt.Println("server exited with error:", err)
 				fmt.Printf("output:\n%s", buf.String())
 				// T.Fail cannot be called from a goroutine
-				failExit()
+				suite.Stop()
+				os.Exit(1)
 			}
 		}
 	}()
@@ -155,10 +153,4 @@ func (suite *IntegrationSuite) ResetDB() {
 func (suite *IntegrationSuite) runQuery(db *sql.DB, query string) {
 	_, err := db.Exec(query)
 	suite.Require().NoError(err, "can't execute SQL: %q", query)
-}
-
-func failExit() {
-	stop()
-
-	os.Exit(1)
 }

--- a/util/cmdtest/grep.go
+++ b/util/cmdtest/grep.go
@@ -11,38 +11,41 @@ import (
 )
 
 // GrepTimeout defines timeout grep is waiting for substring
-var GrepTimeout = time.Minute
+var GrepTimeout = 30 * time.Second
 
 // GrepTrue reads from reader until finds substring with timeout or fails printing read lines
-func GrepTrue(r io.Reader, substr string) {
-	found, buf := Grep(r, substr)
+func (s *IntegrationSuite) GrepTrue(r io.Reader, substr string) {
+	found, buf := s.Grep(r, substr)
 	if !found {
 		fmt.Printf("'%s' is not found in output:\n", substr)
 		fmt.Println(buf.String())
-		failExit()
+		s.Stop()
+		s.Suite.T().Fail()
 	}
 }
 
 // GrepAndNot reads from reader until finds substring with timeout and checks noSubstr was read
 // or fails printing read lines
-func GrepAndNot(r io.Reader, substr, noSubstr string) {
-	found, buf := Grep(r, substr)
+func (s *IntegrationSuite) GrepAndNot(r io.Reader, substr, noSubstr string) {
+	found, buf := s.Grep(r, substr)
 	if !found {
 		fmt.Printf("'%s' is not found in output:\n", substr)
 		fmt.Println(buf.String())
-		failExit()
+		s.Stop()
+		s.Suite.T().Fail()
 		return
 	}
 	if strings.Contains(buf.String(), noSubstr) {
 		fmt.Printf("'%s' should not be in output:\n", noSubstr)
 		fmt.Println(buf.String())
-		failExit()
+		s.Stop()
+		s.Suite.T().Fail()
 	}
 }
 
 // Grep reads from reader until finds substring with timeout
 // return result and content that was read
-func Grep(r io.Reader, substr string) (bool, *bytes.Buffer) {
+func (s *IntegrationSuite) Grep(r io.Reader, substr string) (bool, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
 
 	foundch := make(chan bool, 1)
@@ -60,7 +63,6 @@ func Grep(r io.Reader, substr string) (bool, *bytes.Buffer) {
 			fmt.Fprintln(os.Stderr, "reading input:", err)
 		}
 	}()
-
 	select {
 	case <-time.After(GrepTimeout):
 		return false, buf


### PR DESCRIPTION
After #164 there was an NPE on `GrepTrue()` when no matches were found, that lead to

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x135af74]

goroutine 33 [running]:
github.com/src-d/lookout/util/cmdtest.failExit()
    ~/go/src/github.com/src-d/lookout/util/cmdtest/cmds.go:161 +0x24
```

Which was hard to notice, until your tests are expected to fail like in [here](https://travis-ci.org/src-d/lookout/jobs/422977538) due to not changing the fixture properly.

TEST PLAN:
 - `suite.GrepTrue(strings.NewReader("no shit"),` :hankey:`)`
   fails now

