### PR TITLE
Log config on lookoutd serve startup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,6 +276,13 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:5cb64ae11c6690416028ba76726f101ffc669cbfacf05cdb5607c52bcfff11a0"
+  name = "github.com/sanity-io/litter"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "09e3a73d5b65eac2f14578aec8fb74ee9b4f1a5e"
+
+[[projects]]
   digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
   name = "github.com/satori/go.uuid"
   packages = ["."]
@@ -669,6 +676,7 @@
     "github.com/grpc-ecosystem/go-grpc-middleware/logging",
     "github.com/jessevdk/go-flags",
     "github.com/lib/pq",
+    "github.com/sanity-io/litter",
     "github.com/satori/go.uuid",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -153,6 +153,14 @@
   version = "v1.4.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6c2f939d99ad2074a4113c36aa93fa792ede8ff0b8cdb97634b41b9c5da7fab6"
+  name = "github.com/jinzhu/copier"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "7e38e58719c33e0d44d585c4ab477a30f8cb82dd"
+
+[[projects]]
   digest = "1:8021af4dcbd531ae89433c8c3a6520e51064114aaf8eb1724c3cf911c497c9ba"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
@@ -675,6 +683,7 @@
     "github.com/grpc-ecosystem/go-grpc-middleware",
     "github.com/grpc-ecosystem/go-grpc-middleware/logging",
     "github.com/jessevdk/go-flags",
+    "github.com/jinzhu/copier",
     "github.com/lib/pq",
     "github.com/sanity-io/litter",
     "github.com/satori/go.uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,3 +80,7 @@
 [[constraint]]
   name = "gopkg.in/src-d/lookout-sdk.v0"
   revision = "13a9d4e12a91b75bafa30802b1df5c6ea2693fca"
+
+[[constraint]]
+  name = "github.com/sanity-io/litter"
+  revision = "09e3a73d5b65eac2f14578aec8fb74ee9b4f1a5e"

--- a/vendor/github.com/jinzhu/copier/License
+++ b/vendor/github.com/jinzhu/copier/License
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Jinzhu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jinzhu/copier/copier.go
+++ b/vendor/github.com/jinzhu/copier/copier.go
@@ -1,0 +1,185 @@
+package copier
+
+import (
+	"database/sql"
+	"errors"
+	"reflect"
+)
+
+// Copy copy things
+func Copy(toValue interface{}, fromValue interface{}) (err error) {
+	var (
+		isSlice bool
+		amount  = 1
+		from    = indirect(reflect.ValueOf(fromValue))
+		to      = indirect(reflect.ValueOf(toValue))
+	)
+
+	if !to.CanAddr() {
+		return errors.New("copy to value is unaddressable")
+	}
+
+	// Return is from value is invalid
+	if !from.IsValid() {
+		return
+	}
+
+	// Just set it if possible to assign
+	if from.Type().AssignableTo(to.Type()) {
+		to.Set(from)
+		return
+	}
+
+	fromType := indirectType(from.Type())
+	toType := indirectType(to.Type())
+
+	if fromType.Kind() != reflect.Struct || toType.Kind() != reflect.Struct {
+		return
+	}
+
+	if to.Kind() == reflect.Slice {
+		isSlice = true
+		if from.Kind() == reflect.Slice {
+			amount = from.Len()
+		}
+	}
+
+	for i := 0; i < amount; i++ {
+		var dest, source reflect.Value
+
+		if isSlice {
+			// source
+			if from.Kind() == reflect.Slice {
+				source = indirect(from.Index(i))
+			} else {
+				source = indirect(from)
+			}
+
+			// dest
+			dest = indirect(reflect.New(toType).Elem())
+		} else {
+			source = indirect(from)
+			dest = indirect(to)
+		}
+
+		// Copy from field to field or method
+		for _, field := range deepFields(fromType) {
+			name := field.Name
+
+			if fromField := source.FieldByName(name); fromField.IsValid() {
+				// has field
+				if toField := dest.FieldByName(name); toField.IsValid() {
+					if toField.CanSet() {
+						if !set(toField, fromField) {
+							if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
+								return err
+							}
+						}
+					}
+				} else {
+					// try to set to method
+					var toMethod reflect.Value
+					if dest.CanAddr() {
+						toMethod = dest.Addr().MethodByName(name)
+					} else {
+						toMethod = dest.MethodByName(name)
+					}
+
+					if toMethod.IsValid() && toMethod.Type().NumIn() == 1 && fromField.Type().AssignableTo(toMethod.Type().In(0)) {
+						toMethod.Call([]reflect.Value{fromField})
+					}
+				}
+			}
+		}
+
+		// Copy from method to field
+		for _, field := range deepFields(toType) {
+			name := field.Name
+
+			var fromMethod reflect.Value
+			if source.CanAddr() {
+				fromMethod = source.Addr().MethodByName(name)
+			} else {
+				fromMethod = source.MethodByName(name)
+			}
+
+			if fromMethod.IsValid() && fromMethod.Type().NumIn() == 0 && fromMethod.Type().NumOut() == 1 {
+				if toField := dest.FieldByName(name); toField.IsValid() && toField.CanSet() {
+					values := fromMethod.Call([]reflect.Value{})
+					if len(values) >= 1 {
+						set(toField, values[0])
+					}
+				}
+			}
+		}
+
+		if isSlice {
+			if dest.Addr().Type().AssignableTo(to.Type().Elem()) {
+				to.Set(reflect.Append(to, dest.Addr()))
+			} else if dest.Type().AssignableTo(to.Type().Elem()) {
+				to.Set(reflect.Append(to, dest))
+			}
+		}
+	}
+	return
+}
+
+func deepFields(reflectType reflect.Type) []reflect.StructField {
+	var fields []reflect.StructField
+
+	if reflectType = indirectType(reflectType); reflectType.Kind() == reflect.Struct {
+		for i := 0; i < reflectType.NumField(); i++ {
+			v := reflectType.Field(i)
+			if v.Anonymous {
+				fields = append(fields, deepFields(v.Type)...)
+			} else {
+				fields = append(fields, v)
+			}
+		}
+	}
+
+	return fields
+}
+
+func indirect(reflectValue reflect.Value) reflect.Value {
+	for reflectValue.Kind() == reflect.Ptr {
+		reflectValue = reflectValue.Elem()
+	}
+	return reflectValue
+}
+
+func indirectType(reflectType reflect.Type) reflect.Type {
+	for reflectType.Kind() == reflect.Ptr || reflectType.Kind() == reflect.Slice {
+		reflectType = reflectType.Elem()
+	}
+	return reflectType
+}
+
+func set(to, from reflect.Value) bool {
+	if from.IsValid() {
+		if to.Kind() == reflect.Ptr {
+			//set `to` to nil if from is nil
+			if from.Kind() == reflect.Ptr && from.IsNil() {
+				to.Set(reflect.Zero(to.Type()))
+				return true
+			} else if to.IsNil() {
+				to.Set(reflect.New(to.Type().Elem()))
+			}
+			to = to.Elem()
+		}
+
+		if from.Type().ConvertibleTo(to.Type()) {
+			to.Set(from.Convert(to.Type()))
+		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok {
+			err := scanner.Scan(from.Interface())
+			if err != nil {
+				return false
+			}
+		} else if from.Kind() == reflect.Ptr {
+			return set(to, from.Elem())
+		} else {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/sanity-io/litter/LICENSE
+++ b/vendor/github.com/sanity-io/litter/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Sanity.io.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/sanity-io/litter/dump.go
+++ b/vendor/github.com/sanity-io/litter/dump.go
@@ -1,0 +1,462 @@
+package litter
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var packageNameStripperRegexp = regexp.MustCompile("\\b[a-zA-Z_]+[a-zA-Z_0-9]+\\.")
+var compactTypeRegexp = regexp.MustCompile(`\s*([,;{}()])\s*`)
+
+// Dumper is the interface for implementing custom dumper for your types.
+type Dumper interface {
+	LitterDump(w io.Writer)
+}
+
+// Options represents configuration options for litter
+type Options struct {
+	Compact           bool
+	StripPackageNames bool
+	HidePrivateFields bool
+	HomePackage       string
+	Separator         string
+}
+
+// Config is the default config used when calling Dump
+var Config = Options{
+	StripPackageNames: false,
+	HidePrivateFields: true,
+	Separator:         " ",
+}
+
+type dumpState struct {
+	w                  io.Writer
+	depth              int
+	config             *Options
+	pointers           []uintptr
+	visitedPointers    []uintptr
+	currentPointerName string
+	homePackageRegexp  *regexp.Regexp
+}
+
+func (s *dumpState) indent() {
+	if !s.config.Compact {
+		s.w.Write(bytes.Repeat([]byte("  "), s.depth))
+	}
+}
+
+func (s *dumpState) newlineWithPointerNameComment() {
+	if s.currentPointerName != "" {
+		if s.config.Compact {
+			s.w.Write([]byte(fmt.Sprintf("/*%s*/", s.currentPointerName)))
+		} else {
+			s.w.Write([]byte(fmt.Sprintf(" // %s\n", s.currentPointerName)))
+		}
+		s.currentPointerName = ""
+		return
+	}
+	if !s.config.Compact {
+		s.w.Write([]byte("\n"))
+	}
+}
+
+func (s *dumpState) dumpType(v reflect.Value) {
+	typeName := v.Type().String()
+	if s.config.StripPackageNames {
+		typeName = packageNameStripperRegexp.ReplaceAllLiteralString(typeName, "")
+	} else if s.homePackageRegexp != nil {
+		typeName = s.homePackageRegexp.ReplaceAllLiteralString(typeName, "")
+	}
+	if s.config.Compact {
+		typeName = compactTypeRegexp.ReplaceAllString(typeName, "$1")
+	}
+	s.w.Write([]byte(typeName))
+}
+
+func (s *dumpState) dumpSlice(v reflect.Value) {
+	s.dumpType(v)
+	numEntries := v.Len()
+	if numEntries == 0 {
+		s.w.Write([]byte("{}"))
+		if s.config.Compact {
+			s.w.Write([]byte(";"))
+		}
+		s.newlineWithPointerNameComment()
+		return
+	}
+	s.w.Write([]byte("{"))
+	s.newlineWithPointerNameComment()
+	s.depth++
+	for i := 0; i < numEntries; i++ {
+		s.indent()
+		s.dumpVal(v.Index(i))
+		if !s.config.Compact || i < numEntries-1 {
+			s.w.Write([]byte(","))
+		}
+		s.newlineWithPointerNameComment()
+	}
+	s.depth--
+	s.indent()
+	s.w.Write([]byte("}"))
+}
+
+func (s *dumpState) dumpStruct(v reflect.Value) {
+	dumpPreamble := func() {
+		s.dumpType(v)
+		s.w.Write([]byte("{"))
+		s.newlineWithPointerNameComment()
+		s.depth++
+	}
+	preambleDumped := false
+	vt := v.Type()
+	numFields := v.NumField()
+	for i := 0; i < numFields; i++ {
+		vtf := vt.Field(i)
+		if s.config.HidePrivateFields && vtf.PkgPath != "" {
+			continue
+		}
+		if !preambleDumped {
+			dumpPreamble()
+			preambleDumped = true
+		}
+		s.indent()
+		s.w.Write([]byte(vtf.Name))
+		if s.config.Compact {
+			s.w.Write([]byte(":"))
+		} else {
+			s.w.Write([]byte(": "))
+		}
+		s.dumpVal(v.Field(i))
+		if !s.config.Compact || i < numFields-1 {
+			s.w.Write([]byte(","))
+		}
+		s.newlineWithPointerNameComment()
+	}
+	if preambleDumped {
+		s.depth--
+		s.indent()
+		s.w.Write([]byte("}"))
+	} else {
+		// There were no fields dumped
+		s.dumpType(v)
+		s.w.Write([]byte("{}"))
+	}
+}
+
+func (s *dumpState) dumpMap(v reflect.Value) {
+	s.dumpType(v)
+	s.w.Write([]byte("{"))
+	s.newlineWithPointerNameComment()
+	s.depth++
+	keys := v.MapKeys()
+	sort.Sort(mapKeySorter{
+		keys:    keys,
+		options: s.config,
+	})
+	numKeys := len(keys)
+	for i, key := range keys {
+		s.indent()
+		s.dumpVal(key)
+		if s.config.Compact {
+			s.w.Write([]byte(":"))
+		} else {
+			s.w.Write([]byte(": "))
+		}
+		s.dumpVal(v.MapIndex(key))
+		if !s.config.Compact || i < numKeys-1 {
+			s.w.Write([]byte(","))
+		}
+		s.newlineWithPointerNameComment()
+	}
+	s.depth--
+	s.indent()
+	s.w.Write([]byte("}"))
+}
+
+func (s *dumpState) dumpFunc(v reflect.Value) {
+	parts := strings.Split(runtime.FuncForPC(v.Pointer()).Name(), "/")
+	name := parts[len(parts)-1]
+
+	// Anonymous function
+	if strings.Count(name, ".") > 1 {
+		s.dumpType(v)
+	} else {
+		if s.config.StripPackageNames {
+			name = packageNameStripperRegexp.ReplaceAllLiteralString(name, "")
+		} else if s.homePackageRegexp != nil {
+			name = s.homePackageRegexp.ReplaceAllLiteralString(name, "")
+		}
+		if s.config.Compact {
+			name = compactTypeRegexp.ReplaceAllString(name, "$1")
+		}
+		s.w.Write([]byte(name))
+	}
+}
+
+func (s *dumpState) dumpCustom(v reflect.Value) {
+	// Run the custom dumper buffering the output
+	buf := new(bytes.Buffer)
+	dumpFunc := v.MethodByName("LitterDump")
+	dumpFunc.Call([]reflect.Value{reflect.ValueOf(buf)})
+
+	// Dump the type
+	s.dumpType(v)
+
+	if s.config.Compact {
+		s.w.Write(buf.Bytes())
+		return
+	}
+
+	// Now output the dump taking care to apply the current indentation-level
+	// and pointer name comments.
+	var err error
+	firstLine := true
+	for err == nil {
+		var lineBytes []byte
+		lineBytes, err = buf.ReadBytes('\n')
+		line := strings.TrimRight(string(lineBytes), " \n")
+
+		if err != nil && err != io.EOF {
+			break
+		}
+		// Do not indent first line
+		if firstLine {
+			firstLine = false
+		} else {
+			s.indent()
+		}
+		s.w.Write([]byte(line))
+
+		// At EOF we're done
+		if err == io.EOF {
+			return
+		}
+		s.newlineWithPointerNameComment()
+	}
+	panic(err)
+}
+
+func (s *dumpState) dump(value interface{}) {
+	if value == nil {
+		printNil(s.w)
+		return
+	}
+	v := reflect.ValueOf(value)
+	s.dumpVal(v)
+}
+
+func (s *dumpState) handlePointerAliasingAndCheckIfShouldDescend(value reflect.Value) bool {
+	pointerName, firstVisit := s.pointerNameFor(value)
+	if pointerName == "" {
+		return true
+	}
+	if firstVisit {
+		s.currentPointerName = pointerName
+		return true
+	}
+	s.w.Write([]byte(pointerName))
+	return false
+}
+
+func (s *dumpState) dumpVal(value reflect.Value) {
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		s.w.Write([]byte("nil"))
+		return
+	}
+
+	v := deInterface(value)
+	kind := v.Kind()
+
+	// Handle custom dumpers
+	dumperType := reflect.TypeOf((*Dumper)(nil)).Elem()
+	if v.Type().Implements(dumperType) {
+		if s.handlePointerAliasingAndCheckIfShouldDescend(v) {
+			s.dumpCustom(v)
+		}
+		return
+	}
+
+	switch kind {
+	case reflect.Invalid:
+		// Do nothing.  We should never get here since invalid has already
+		// been handled above.
+		s.w.Write([]byte("<invalid>"))
+
+	case reflect.Bool:
+		printBool(s.w, v.Bool())
+
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		printInt(s.w, v.Int(), 10)
+
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		printUint(s.w, v.Uint(), 10)
+
+	case reflect.Float32:
+		printFloat(s.w, v.Float(), 32)
+
+	case reflect.Float64:
+		printFloat(s.w, v.Float(), 64)
+
+	case reflect.Complex64:
+		printComplex(s.w, v.Complex(), 32)
+
+	case reflect.Complex128:
+		printComplex(s.w, v.Complex(), 64)
+
+	case reflect.String:
+		s.w.Write([]byte(strconv.Quote(v.String())))
+
+	case reflect.Slice:
+		if v.IsNil() {
+			printNil(s.w)
+			break
+		}
+		fallthrough
+
+	case reflect.Array:
+		if s.handlePointerAliasingAndCheckIfShouldDescend(v) {
+			s.dumpSlice(v)
+		}
+
+	case reflect.Interface:
+		// The only time we should get here is for nil interfaces due to
+		// unpackValue calls.
+		if v.IsNil() {
+			printNil(s.w)
+		}
+
+	case reflect.Ptr:
+		if s.handlePointerAliasingAndCheckIfShouldDescend(v) {
+			s.w.Write([]byte("&"))
+			s.dumpVal(v.Elem())
+		}
+
+	case reflect.Map:
+		if s.handlePointerAliasingAndCheckIfShouldDescend(v) {
+			s.dumpMap(v)
+		}
+
+	case reflect.Struct:
+		s.dumpStruct(v)
+
+	case reflect.Func:
+		s.dumpFunc(v)
+
+	default:
+		if v.CanInterface() {
+			fmt.Fprintf(s.w, "%v", v.Interface())
+		} else {
+			fmt.Fprintf(s.w, "%v", v.String())
+		}
+	}
+}
+
+// call to signal that the pointer is being visited, returns true if this is the
+// first visit to that pointer. Used to detect when to output the entire contents
+// behind a pointer (the first time), and when to just emit a name (all other times)
+func (s *dumpState) visitPointerAndCheckIfItIsTheFirstTime(ptr uintptr) bool {
+	for _, addr := range s.visitedPointers {
+		if addr == ptr {
+			return false
+		}
+	}
+	s.visitedPointers = append(s.visitedPointers, ptr)
+	return true
+}
+
+// registers that the value has been visited and checks to see if it is one of the
+// pointers we will see multiple times. If it is, it returns a temporary name for this
+// pointer. It also returns a boolean value indicating whether this is the first time
+// this name is returned so the caller can decide whether the contents of the pointer
+// has been dumped before or not.
+func (s *dumpState) pointerNameFor(v reflect.Value) (string, bool) {
+	if isPointerValue(v) {
+		ptr := v.Pointer()
+		for i, addr := range s.pointers {
+			if ptr == addr {
+				firstVisit := s.visitPointerAndCheckIfItIsTheFirstTime(ptr)
+				return fmt.Sprintf("p%d", i), firstVisit
+			}
+		}
+	}
+	return "", false
+}
+
+// prepares a new state object for dumping the provided value
+func newDumpState(value interface{}, options *Options, writer io.Writer) *dumpState {
+	result := &dumpState{
+		config:   options,
+		pointers: MapReusedPointers(reflect.ValueOf(value)),
+		w:        writer,
+	}
+
+	if options.HomePackage != "" {
+		result.homePackageRegexp = regexp.MustCompile(fmt.Sprintf("\\b%s\\.", options.HomePackage))
+	}
+
+	return result
+}
+
+// Dump a value to stdout
+func Dump(value ...interface{}) {
+	(&Config).Dump(value...)
+}
+
+// Sdump dumps a value to a string
+func Sdump(value ...interface{}) string {
+	return (&Config).Sdump(value...)
+}
+
+// Dump a value to stdout according to the options
+func (o Options) Dump(values ...interface{}) {
+	for i, value := range values {
+		state := newDumpState(value, &o, os.Stdout)
+		if i > 0 {
+			state.w.Write([]byte(o.Separator))
+		}
+		state.dump(value)
+	}
+	os.Stdout.Write([]byte("\n"))
+}
+
+// Sdump dumps a value to a string according to the options
+func (o Options) Sdump(values ...interface{}) string {
+	buf := new(bytes.Buffer)
+	for i, value := range values {
+		if i > 0 {
+			buf.Write([]byte(o.Separator))
+		}
+		state := newDumpState(value, &o, buf)
+		state.dump(value)
+	}
+	return buf.String()
+}
+
+type mapKeySorter struct {
+	keys    []reflect.Value
+	options *Options
+}
+
+func (s mapKeySorter) Len() int {
+	return len(s.keys)
+}
+
+func (s mapKeySorter) Swap(i, j int) {
+	s.keys[i], s.keys[j] = s.keys[j], s.keys[i]
+}
+
+func (s mapKeySorter) Less(i, j int) bool {
+	ibuf := new(bytes.Buffer)
+	jbuf := new(bytes.Buffer)
+	newDumpState(s.keys[i], s.options, ibuf).dumpVal(s.keys[i])
+	newDumpState(s.keys[j], s.options, jbuf).dumpVal(s.keys[j])
+	return ibuf.String() < jbuf.String()
+}

--- a/vendor/github.com/sanity-io/litter/mapper.go
+++ b/vendor/github.com/sanity-io/litter/mapper.go
@@ -1,0 +1,92 @@
+package litter
+
+import (
+	"reflect"
+	"sort"
+)
+
+type pointerMap struct {
+	pointers       []uintptr
+	reusedPointers []uintptr
+}
+
+// MapReusedPointers : Given a structure, it will recurively map all pointers mentioned in the tree, breaking
+// circular references and provide a list of all pointers that was referenced at least twice
+// by the provided structure.
+func MapReusedPointers(v reflect.Value) []uintptr {
+	pm := &pointerMap{
+		reusedPointers: []uintptr{},
+	}
+	pm.consider(v)
+	return pm.reusedPointers
+}
+
+// Recursively consider v and each of its children, updating the map according to the
+// semantics of MapReusedPointers
+func (pm *pointerMap) consider(v reflect.Value) {
+	if v.Kind() == reflect.Invalid {
+		return
+	}
+	// fmt.Printf("Considering [%s] %#v\n\r", v.Type().String(), v.Interface())
+	if isPointerValue(v) && v.Pointer() != 0 { // pointer is 0 for unexported fields
+		// fmt.Printf("Ptr is %d\n\r", v.Pointer())
+		reused := pm.addPointerReturnTrueIfWasReused(v.Pointer())
+		if reused {
+			// No use descending inside this value, since it have been seen before and all its descendants
+			// have been considered
+			return
+		}
+	}
+
+	// Now descend into any children of this value
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		numEntries := v.Len()
+		for i := 0; i < numEntries; i++ {
+			pm.consider(v.Index(i))
+		}
+
+	case reflect.Interface:
+		pm.consider(v.Elem())
+
+	case reflect.Ptr:
+		pm.consider(v.Elem())
+
+	case reflect.Map:
+		keys := v.MapKeys()
+		sort.Sort(mapKeySorter{
+			keys:    keys,
+			options: &Config,
+		})
+		for _, key := range keys {
+			pm.consider(v.MapIndex(key))
+		}
+
+	case reflect.Struct:
+		numFields := v.NumField()
+		for i := 0; i < numFields; i++ {
+			pm.consider(v.Field(i))
+		}
+	}
+}
+
+// addPointer to the pointerMap, update reusedPointers. Returns true if pointer was reused
+func (pm *pointerMap) addPointerReturnTrueIfWasReused(ptr uintptr) bool {
+	// Is this allready known to be reused?
+	for _, have := range pm.reusedPointers {
+		if ptr == have {
+			return true
+		}
+	}
+	// Have we seen it once before?
+	for _, seen := range pm.pointers {
+		if ptr == seen {
+			// Add it to the register of pointers we have seen more than once
+			pm.reusedPointers = append(pm.reusedPointers, ptr)
+			return true
+		}
+	}
+	// This pointer was new to us
+	pm.pointers = append(pm.pointers, ptr)
+	return false
+}

--- a/vendor/github.com/sanity-io/litter/print.go
+++ b/vendor/github.com/sanity-io/litter/print.go
@@ -1,0 +1,44 @@
+package litter
+
+import (
+	"io"
+	"strconv"
+)
+
+func printBool(w io.Writer, value bool) {
+	if value {
+		w.Write([]byte("true"))
+		return
+	}
+	w.Write([]byte("false"))
+}
+
+func printInt(w io.Writer, val int64, base int) {
+	w.Write([]byte(strconv.FormatInt(val, base)))
+}
+
+func printUint(w io.Writer, val uint64, base int) {
+	w.Write([]byte(strconv.FormatUint(val, base)))
+}
+
+func printFloat(w io.Writer, val float64, precision int) {
+	w.Write([]byte(strconv.FormatFloat(val, 'g', -1, precision)))
+}
+
+func printComplex(w io.Writer, c complex128, floatPrecision int) {
+	w.Write([]byte("complex"))
+	printInt(w, int64(floatPrecision*2), 10)
+	r := real(c)
+	w.Write([]byte("("))
+	w.Write([]byte(strconv.FormatFloat(r, 'g', -1, floatPrecision)))
+	i := imag(c)
+	if i >= 0 {
+		w.Write([]byte("+"))
+	}
+	w.Write([]byte(strconv.FormatFloat(i, 'g', -1, floatPrecision)))
+	w.Write([]byte("i)"))
+}
+
+func printNil(w io.Writer) {
+	w.Write([]byte("nil"))
+}

--- a/vendor/github.com/sanity-io/litter/util.go
+++ b/vendor/github.com/sanity-io/litter/util.go
@@ -1,0 +1,21 @@
+package litter
+
+import "reflect"
+
+// deInterface returns values inside of non-nil interfaces when possible.
+// This is useful for data types like structs, arrays, slices, and maps which
+// can contain varying types packed inside an interface.
+func deInterface(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Interface && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v
+}
+
+func isPointerValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Part of #181.

DB config left intentionally out, as it may contain the password.
I'm initializing the structs this way to avoid changing a pointer reference accidentally, and to avoid leaking by mistake any future fields that may contain credentials.

The output will be similar to this:
```
[2018-09-04T14:57:52.179461203+01:00]  INFO starting lookoutd conf=main.Config{
  Config: server.Config{
    Analyzers: []lookout.AnalyzerConfig{
      lookout.AnalyzerConfig{
        Name: "Dummy",
        Addr: "ipv4://localhost:10302",
        Disabled: false,
        Feedback: "https://github.com/carlosms-bot/analyzer-comments/issues/new?template=feedback.md",
        Settings: map[string]interface {}{
        },
      },
    },
  },
  Providers: struct { Github github.ProviderConfig }{
    Github: github.ProviderConfig{
      CommentFooter: "_If you have feedback about this comment please, [tell us](%s)._",
    },
  },
  Repositories: []main.RepoConfig{
    main.RepoConfig{
      URL: "https://github.com/carlosms/lookout-test",
      Client: github.ClientConfig{
        User: "",
        Token: "****",
        MinInterval: "",
      },
    },
  },
} options=main.ServeCommand{
  CommonOptions: cli.CommonOptions{
    LogOptions: cli.LogOptions{
      LogLevel: "DEBUG",
      LogFormat: "",
      LogFields: "",
      LogForceFormat: false,
      Verbose: false,
    },
    GrpcMaxMsgSize: 100,
  },
  DBOptions: cli.DBOptions{
    DB: "",
  },
  ConfigFile: "config.yml",
  GithubUser: "",
  GithubToken: "****",
  DataServer: "ipv4://localhost:10301",
  Bblfshd: "ipv4://localhost:9432",
  DryRun: true,
  Library: "/tmp/lookout",
  Provider: "github",
  Positional: struct { Repository string "positional-arg-name:\"repository\"" }{
    Repository: "https://github.com/carlosms/lookout-test",
  },
} source=lookoutd/serve.go:175

```