### PR TITLE
Skip posting comments on files not part of the diff

### DIFF
--- a/provider/github/diff.go
+++ b/provider/github/diff.go
@@ -17,6 +17,8 @@ var (
 	// ErrLineNotAddition is returned when the file line number is not
 	// a + change in the patch diff
 	ErrLineNotAddition = errors.NewKind("line number is not an added change")
+	// ErrFileNotFound is returned when the file name is not part of the diff
+	ErrFileNotFound = errors.NewKind("file not found")
 )
 
 type diffLines struct {
@@ -120,7 +122,7 @@ func (d *diffLines) hunks(file string) ([]*hunk, map[int]bool, error) {
 	}
 
 	if ff == nil {
-		return nil, nil, fmt.Errorf("file not found: %s", file)
+		return nil, nil, ErrFileNotFound.New()
 	}
 
 	if ff.Patch == nil {


### PR DESCRIPTION
Fix #197.

After trying to reproduce the bug (here https://github.com/src-d/lookout-test-fixtures/pull/1), I found that our dummy and gometalint seem to work OK. They do not create comments for files that are not part of the diff.

So either I didn't recreate the exact scenario, we fixed something in these analyzers, or it was the style analyzer. We can't know because the logs do not show the analyzer (and version) that provides each comment.

I any case, I decided to create this PR to skip such malformed comments when it happens again.
The same way we skip comments out of the diff range, this PR skips comments for files that do not have changes. Otherwise the review fails because of buggy analyzers, when maybe there are comments from other analyzers that we can post.