### PR TITLE
Remove CLI positional argument

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -1,6 +1,5 @@
 app:
   lookout:
-    repository: github.com/src-d/lookout,github.com/bblfsh/uast-viewer
     logLevel: debug
     secretName: lookout-github-credentials
     dbConnectionString: postgres://lookout:lookout@lookout-postgresql:5432/lookout?sslmode=disable
@@ -13,6 +12,10 @@ nodeSelector:
 nodeSelector:
  dummyAnalyzer:
    srcd.host/type: worker
+
+repositories:
+  - url: github.com/src-d/lookout
+  - url: github.com/bblfsh/uast-viewer
 
 providers:
   github:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ clean-all:
 
 .PHONY: dry-run
 dry-run: $(CONFIG_FILE)
-	go run cmd/lookoutd/*.go serve --dry-run github.com/src-d/lookout
+	go run cmd/lookoutd/*.go serve --dry-run
 $(CONFIG_FILE):
 	cp "$(CONFIG_FILE).tpl" $(CONFIG_FILE)
 

--- a/cmd/lookoutd/serve.go
+++ b/cmd/lookoutd/serve.go
@@ -256,21 +256,14 @@ func (c *ServeCommand) initPoster(conf Config) (lookout.Poster, error) {
 func (c *ServeCommand) initWatcher(conf Config) (lookout.Watcher, error) {
 	switch c.Provider {
 	case github.Provider:
-		urls := make([]string, len(conf.Repositories))
-		for i, repo := range conf.Repositories {
-			urls[i] = repo.URL
-		}
-
-		watcher, err := github.NewWatcher(c.pool, &lookout.WatchOptions{
-			URLs: urls,
-		})
+		watcher, err := github.NewWatcher(c.pool)
 		if err != nil {
 			return nil, err
 		}
 
 		return watcher, nil
 	case json.Provider:
-		return json.NewWatcher(os.Stdin, &lookout.WatchOptions{})
+		return json.NewWatcher(os.Stdin)
 	default:
 		return nil, fmt.Errorf("provider %s not supported", c.Provider)
 	}

--- a/cmd/lookoutd/serve.go
+++ b/cmd/lookoutd/serve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/provider/github"
@@ -51,9 +50,6 @@ type ServeCommand struct {
 	DryRun      bool   `long:"dry-run" env:"LOOKOUT_DRY_RUN" description:"analyze repositories and log the result without posting code reviews to GitHub"`
 	Library     string `long:"library" default:"/tmp/lookout" env:"LOOKOUT_LIBRARY" description:"path to the lookout library"`
 	Provider    string `long:"provider" default:"github" env:"LOOKOUT_PROVIDER" description:"provider name: github, json"`
-	Positional  struct {
-		Repository string `positional-arg-name:"repository"`
-	} `positional-args:"yes" required:"yes"`
 
 	analyzers map[string]lookout.AnalyzerClient
 	pool      *github.ClientPool
@@ -154,8 +150,14 @@ func (c *ServeCommand) logConfig(conf Config) {
 	var confCp Config
 	copier.Copy(&confCp, conf)
 
-	for i := range confCp.Repositories {
-		confCp.Repositories[i].Client.Token = "****"
+	confCp.Repositories = make([]RepoConfig, len(conf.Repositories))
+	for i := range conf.Repositories {
+		var repoConfigCp RepoConfig
+		copier.Copy(&repoConfigCp, conf.Repositories[i])
+		if repoConfigCp.Client.Token != "" {
+			repoConfigCp.Client.Token = "****"
+		}
+		confCp.Repositories[i] = repoConfigCp
 	}
 
 	lt := litter.Options{
@@ -188,18 +190,13 @@ func (c *ServeCommand) initProviderGithubToken(conf Config) error {
 		Token: c.GithubToken,
 	}
 
-	urls := strings.Split(c.Positional.Repository, ",")
-	urlToConfig := make(map[string]github.ClientConfig, len(urls))
 	repoToConfig := make(map[string]github.ClientConfig, len(conf.Repositories))
 	for _, repo := range conf.Repositories {
-		if !repo.Client.IsZero() {
-			repoToConfig[repo.URL] = repo.Client
-		}
+		repoToConfig[repo.URL] = repo.Client
 	}
 
-	for _, url := range urls {
-		conf, ok := repoToConfig[url]
-		if !ok {
+	for url, config := range repoToConfig {
+		if config.IsZero() {
 			if noDefaultAuth {
 				// Empty github auth is only useful for --dry-run,
 				// we may want to enforce this as an error
@@ -208,13 +205,12 @@ func (c *ServeCommand) initProviderGithubToken(conf Config) error {
 				log.Infof("using default authentication for repository %s", url)
 			}
 
-			conf = defaultConfig
+			repoToConfig[url] = defaultConfig
 		}
-		urlToConfig[url] = conf
 	}
 
 	cache := cache.NewValidableCache(diskcache.New("/tmp/github"))
-	pool, err := github.NewClientPoolFromTokens(urlToConfig, cache)
+	pool, err := github.NewClientPoolFromTokens(repoToConfig, cache)
 	if err != nil {
 		return err
 	}
@@ -224,8 +220,6 @@ func (c *ServeCommand) initProviderGithubToken(conf Config) error {
 }
 
 func (c *ServeCommand) initProviderGithubApp(conf Config) error {
-	log.Warningf("with GitHub App authentication the repository argument is ignored")
-
 	if conf.Providers.Github.PrivateKey == "" {
 		return fmt.Errorf("missing GitHub App private key filepath in config")
 	}
@@ -262,8 +256,13 @@ func (c *ServeCommand) initPoster(conf Config) (lookout.Poster, error) {
 func (c *ServeCommand) initWatcher(conf Config) (lookout.Watcher, error) {
 	switch c.Provider {
 	case github.Provider:
+		urls := make([]string, len(conf.Repositories))
+		for i, repo := range conf.Repositories {
+			urls[i] = repo.URL
+		}
+
 		watcher, err := github.NewWatcher(c.pool, &lookout.WatchOptions{
-			URLs: strings.Split(c.Positional.Repository, ","),
+			URLs: urls,
 		})
 		if err != nil {
 			return nil, err

--- a/cmd/server-test/dummy_analyzer_test.go
+++ b/cmd/server-test/dummy_analyzer_test.go
@@ -20,7 +20,7 @@ func (suite *DummyIntegrationSuite) SetupTest() {
 	suite.StoppableCtx()
 	suite.StartDummy("--files")
 	suite.r, suite.w = suite.StartServe("--provider", "json",
-		"-c", dummyConfigFile, "dummy-repo-url")
+		"-c", dummyConfigFile)
 
 	// make sure server started correctly
 	suite.GrepTrue(suite.r, "Starting watcher")

--- a/cmd/server-test/error_analyzer_test.go
+++ b/cmd/server-test/error_analyzer_test.go
@@ -56,7 +56,7 @@ func (suite *ErrorAnalyzerIntegrationSuite) SetupTest() {
 	suite.StoppableCtx()
 	suite.startAnalyzer(suite.Ctx, &errAnalyzer{})
 	suite.r, suite.w = suite.StartServe("--provider", "json",
-		"-c", "../../fixtures/dummy_config.yml", "dummy-repo-url")
+		"-c", "../../fixtures/dummy_config.yml")
 
 	// make sure server started correctly
 	suite.GrepTrue(suite.r, "Starting watcher")

--- a/cmd/server-test/multi_analyzer_test.go
+++ b/cmd/server-test/multi_analyzer_test.go
@@ -22,7 +22,7 @@ func (suite *MultiDummyIntegrationSuite) SetupTest() {
 	suite.StartDummy("--files")
 	suite.StartDummy("--files", "--analyzer", "ipv4://localhost:10303")
 	suite.r, suite.w = suite.StartServe("--provider", "json",
-		"-c", dubleDummyConfigFile, "dummy-repo-url")
+		"-c", dubleDummyConfigFile)
 
 	// make sure server started correctly
 	suite.GrepTrue(suite.r, "Starting watcher")

--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -31,6 +31,16 @@ func (p *ClientPool) Client(username, repo string) (*Client, bool) {
 	return c, ok
 }
 
+// Repos returns list of repositories in the pool
+func (p *ClientPool) Repos() []string {
+	var rps []string
+	for r := range p.byRepo {
+		rps = append(rps, r)
+	}
+
+	return rps
+}
+
 // Client is a wrapper for github.Client that supports cache and provides rate limit information
 type Client struct {
 	*github.Client

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -37,20 +37,18 @@ var (
 
 type Watcher struct {
 	pool *ClientPool
-	o    *lookout.WatchOptions
 }
 
 // NewWatcher returns a new
-func NewWatcher(pool *ClientPool, o *lookout.WatchOptions) (*Watcher, error) {
+func NewWatcher(pool *ClientPool) (*Watcher, error) {
 	return &Watcher{
 		pool: pool,
-		o:    o,
 	}, nil
 }
 
 // Watch start to make request to the GitHub API and return the new events.
 func (w *Watcher) Watch(ctx context.Context, cb lookout.EventHandler) error {
-	ctxlog.Get(ctx).With(log.Fields{"urls": w.o.URLs}).Infof("Starting watcher")
+	ctxlog.Get(ctx).With(log.Fields{"repos": w.pool.Repos()}).Infof("Starting watcher")
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -84,9 +84,7 @@ const (
 
 func (s *WatcherTestSuite) newWatcher(repoURLs []string) *Watcher {
 	pool := newTestPool(s.Suite, repoURLs, s.githubURL, s.cache)
-	w, err := NewWatcher(pool, &lookout.WatchOptions{
-		URLs: repoURLs,
-	})
+	w, err := NewWatcher(pool)
 
 	s.NoError(err)
 
@@ -311,9 +309,7 @@ func (s *WatcherTestSuite) TestCustomMinInterval() {
 		byRepo: map[string]*Client{"mock/test": client},
 	}
 
-	w, err := NewWatcher(pool, &lookout.WatchOptions{
-		URLs: []string{"github.com/mock/test"},
-	})
+	w, err := NewWatcher(pool)
 	s.NoError(err)
 
 	globalTimeout := clientMinInterval * 3

--- a/provider/json/watcher.go
+++ b/provider/json/watcher.go
@@ -18,14 +18,12 @@ const Provider = "json"
 
 // Watcher watches for new json events in the console
 type Watcher struct {
-	o       *lookout.WatchOptions
 	scanner *bufio.Scanner
 }
 
 // NewWatcher returns a new json console watcher
-func NewWatcher(reader io.Reader, o *lookout.WatchOptions) (*Watcher, error) {
+func NewWatcher(reader io.Reader) (*Watcher, error) {
 	return &Watcher{
-		o:       o,
 		scanner: bufio.NewScanner(reader),
 	}, nil
 }

--- a/provider/json/watcher_test.go
+++ b/provider/json/watcher_test.go
@@ -36,7 +36,7 @@ func init() {
 func (s *WatcherTestSuite) TestWatch() {
 	var events int
 
-	w, err := NewWatcher(strings.NewReader(pushJSON+"\n"+reviewJSON), &lookout.WatchOptions{})
+	w, err := NewWatcher(strings.NewReader(pushJSON + "\n" + reviewJSON))
 
 	s.NoError(err)
 
@@ -60,7 +60,7 @@ func (s *WatcherTestSuite) TestWatch() {
 func (s *WatcherTestSuite) TestWatch_WrongEvent() {
 	var events int
 
-	w, err := NewWatcher(strings.NewReader(badEvent), &lookout.WatchOptions{})
+	w, err := NewWatcher(strings.NewReader(badEvent))
 
 	s.NoError(err)
 
@@ -79,7 +79,7 @@ func (s *WatcherTestSuite) TestWatch_WrongEvent() {
 func (s *WatcherTestSuite) TestWatch_BadJSON() {
 	var events int
 
-	w, err := NewWatcher(strings.NewReader(badEvent), &lookout.WatchOptions{})
+	w, err := NewWatcher(strings.NewReader(badEvent))
 
 	s.NoError(err)
 
@@ -96,7 +96,7 @@ func (s *WatcherTestSuite) TestWatch_BadJSON() {
 }
 
 func (s *WatcherTestSuite) TestWatch_WithError() {
-	w, err := NewWatcher(strings.NewReader(pushJSON), &lookout.WatchOptions{})
+	w, err := NewWatcher(strings.NewReader(pushJSON))
 
 	s.NoError(err)
 

--- a/watcher.go
+++ b/watcher.go
@@ -22,8 +22,3 @@ type Watcher interface {
 
 // EventHandler funciton to be called when a new event happends.
 type EventHandler func(Event) error
-
-// WatchOptions options to use in the Watcher constructors.
-type WatchOptions struct {
-	URLs []string
-}


### PR DESCRIPTION
Fix #229 

It looks like chart should work without `repository` value.
Chart would use default one but it will be just ignored by lookout now.