### PR TITLE
Don't walk to parent dirs looking for repository in lookout-sdk

### DIFF
--- a/cmd/lookout-sdk/event.go
+++ b/cmd/lookout-sdk/event.go
@@ -39,10 +39,16 @@ func (c *EventCommand) openRepository() error {
 	var err error
 
 	c.repo, err = gogit.PlainOpenWithOptions(c.GitDir, &gogit.PlainOpenOptions{
-		DetectDotGit: true,
+		// it's useful to walk to parent in case --git-dir is default
+		// but very confusing in all other cases
+		DetectDotGit: c.GitDir == ".",
 	})
 
-	return err
+	if err != nil {
+		return fmt.Errorf("can't open repository at path '%s': %s", c.GitDir, err)
+	}
+
+	return nil
 }
 
 func (c *EventCommand) resolveRefs() (*lookout.ReferencePointer, *lookout.ReferencePointer, error) {


### PR DESCRIPTION
I had an error with resolving revision and spent quite much time figuring out why.

Currently lookout-sdk binary would walk through parents until it finds the root of a repository.
And it does that even if a passed path doesn't exist.

It means any incorrect path with git repo somewhere in the middle of it will be resolved to that repo. It's super confusing.

In my case, I forgot to add `/` at the front of the `--git-dir` so it was resolving to the current repo.

I also added a path to the repo in error message.