### PR TITLE
Improve log fields

### DIFF
--- a/cmd/lookoutd/serve.go
+++ b/cmd/lookoutd/serve.go
@@ -371,7 +371,7 @@ func (c *ServeCommand) initDB() (*sql.DB, error) {
 				"Use '%s migrate' to upgrade your database", dbVersion, version, build, maxVersion, name)
 	}
 
-	log.Debugf("the DB version is up to date, %v", dbVersion)
+	log.With(log.Fields{"db-version": dbVersion}).Debugf("the DB version is up to date")
 	log.Infof("connection with the DB established")
 	return db, nil
 }

--- a/cmd/lookoutd/serve.go
+++ b/cmd/lookoutd/serve.go
@@ -281,7 +281,7 @@ func (c *ServeCommand) startAnalyzer(conf lookout.AnalyzerConfig) (lookout.Analy
 		return nil, err
 	}
 
-	go grpchelper.LogConnStatusChanges(ctx, log.With(log.Fields{
+	go grpchelper.LogConnStatusChanges(ctx, log.DefaultLogger.With(log.Fields{
 		"analyzer": conf.Name,
 		"addr":     conf.Addr,
 	}), conn)

--- a/provider/github/poster.go
+++ b/provider/github/poster.go
@@ -211,6 +211,15 @@ func (p *Poster) createReviewRequest(
 					}).Warningf("skipping comment on a file not part of the diff")
 					continue
 				}
+				if ErrBadPatch.Is(err) {
+					patch, _ := dl.filePatch(c.File)
+					logger.With(log.Fields{
+						"analyzer": aComments.Config.Name,
+						"file":     c.File,
+						"patch":    patch,
+					}).Errorf(err, "skipping comment because the diff could not be parsed")
+					continue
+				}
 
 				if err != nil {
 					return nil, err

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -168,7 +168,7 @@ func (w *Watcher) handlePrs(ctx context.Context, cb lookout.EventHandler, r *loo
 		})
 		event := castPullRequest(ctx, r, e)
 
-		if err := cb(event); err != nil {
+		if err := cb(ctx, event); err != nil {
 			return err
 		}
 	}
@@ -203,7 +203,7 @@ func (w *Watcher) handleEvents(ctx context.Context, cb lookout.EventHandler, r *
 			continue
 		}
 
-		if err := cb(event); err != nil {
+		if err := cb(ctx, event); err != nil {
 			return err
 		}
 	}

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -296,7 +296,7 @@ func (s *WatcherTestSuite) TestCustomMinInterval() {
 	s.mux.HandleFunc("/repos/mock/test/events", eventsHandler(&eventCalls))
 
 	clientMinInterval := 200 * time.Millisecond
-	client := NewClient(nil, s.cache, log.New(log.Fields{}), clientMinInterval.String())
+	client := NewClient(nil, s.cache, clientMinInterval.String())
 	client.BaseURL = s.githubURL
 	client.UploadURL = s.githubURL
 
@@ -338,7 +338,7 @@ func (t *NoopTransport) Get(repo string) http.RoundTripper {
 }
 
 func newTestPool(s suite.Suite, repoURLs []string, githubURL *url.URL, cache *cache.ValidableCache) *ClientPool {
-	client := NewClient(nil, cache, log.DefaultLogger, "")
+	client := NewClient(nil, cache, "")
 	client.BaseURL = githubURL
 	client.UploadURL = githubURL
 

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -103,7 +103,7 @@ func (s *WatcherTestSuite) TestWatch() {
 	defer cancel()
 
 	w := s.newWatcher([]string{"github.com/mock/test-a", "github.com/mock/test-b"})
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		atomic.AddInt32(&events, 1)
 
 		switch e.Type() {
@@ -133,7 +133,7 @@ func (s *WatcherTestSuite) TestWatch_CallbackError_Pull() {
 	s.mux.HandleFunc("/repos/mock/test/events", emptyArrayHandler)
 
 	w := s.newWatcher([]string{"github.com/mock/test"})
-	err := w.Watch(context.TODO(), func(e lookout.Event) error {
+	err := w.Watch(context.TODO(), func(ctx context.Context, e lookout.Event) error {
 		s.Equal(pb.ReviewEventType, e.Type())
 		s.Equal(pullID, e.ID().String())
 
@@ -150,7 +150,7 @@ func (s *WatcherTestSuite) TestWatch_CallbackError_Event() {
 	s.mux.HandleFunc("/repos/mock/test/events", eventsHandler(&calls))
 
 	w := s.newWatcher([]string{"github.com/mock/test"})
-	err := w.Watch(context.TODO(), func(e lookout.Event) error {
+	err := w.Watch(context.TODO(), func(ctx context.Context, e lookout.Event) error {
 		s.Equal(pb.PushEventType, e.Type())
 		s.Equal(pushID, e.ID().String())
 
@@ -178,7 +178,7 @@ func (s *WatcherTestSuite) TestWatch_HttpError() {
 	defer cancel()
 
 	w := s.newWatcher([]string{"github.com/mock/test", "github.com/mock/test-err"})
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		s.Equal("git://github.com/mock/test.git", e.Revision().Head.InternalRepositoryURL)
 		return nil
 	})
@@ -213,7 +213,7 @@ func (s *WatcherTestSuite) TestWatch_HttpTimeout() {
 	defer cancel()
 
 	w := s.newWatcher([]string{"github.com/mock/test", "github.com/mock/test-err"})
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		s.Equal("git://github.com/mock/test.git", e.Revision().Head.InternalRepositoryURL)
 		return nil
 	})
@@ -242,7 +242,7 @@ func (s *WatcherTestSuite) TestWatch_JSONError() {
 	defer cancel()
 
 	w := s.newWatcher([]string{"github.com/mock/test", "github.com/mock/test-err"})
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		return nil
 	})
 
@@ -277,7 +277,7 @@ func (s *WatcherTestSuite) TestWatchLimit() {
 	defer cancel()
 
 	w := s.newWatcher([]string{"github.com/mock/test"})
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		prEvents++
 		s.Equal("fd84071093b69f9aac25fb5dfeea1a870e3e19cf", e.ID().String())
 
@@ -316,7 +316,7 @@ func (s *WatcherTestSuite) TestCustomMinInterval() {
 	ctx, cancel := context.WithTimeout(context.TODO(), globalTimeout)
 	defer cancel()
 
-	err = w.Watch(ctx, func(e lookout.Event) error { return nil })
+	err = w.Watch(ctx, func(ctx context.Context, e lookout.Event) error { return nil })
 
 	s.EqualValues(globalTimeout/clientMinInterval, atomic.LoadInt32(&pullCalls))
 	s.EqualValues(globalTimeout/clientMinInterval, atomic.LoadInt32(&eventCalls))

--- a/provider/json/watcher.go
+++ b/provider/json/watcher.go
@@ -101,5 +101,5 @@ func (w *Watcher) handleInput(ctx context.Context, cb lookout.EventHandler, line
 		return nil
 	}
 
-	return cb(event)
+	return cb(ctx, event)
 }

--- a/provider/json/watcher_test.go
+++ b/provider/json/watcher_test.go
@@ -45,7 +45,7 @@ func (s *WatcherTestSuite) TestWatch() {
 
 	expectedTypes := []pb.EventType{pb.PushEventType, pb.ReviewEventType}
 
-	err = w.Watch(ctx, func(e lookout.Event) error {
+	err = w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		s.Equal(expectedTypes[events], e.Type())
 		s.Equal("http://github.com/foo/bar", e.Revision().Base.InternalRepositoryURL)
 
@@ -67,7 +67,7 @@ func (s *WatcherTestSuite) TestWatch_WrongEvent() {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
 	defer cancel()
 
-	err = w.Watch(ctx, func(e lookout.Event) error {
+	err = w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		events++
 		return nil
 	})
@@ -86,7 +86,7 @@ func (s *WatcherTestSuite) TestWatch_BadJSON() {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
 	defer cancel()
 
-	err = w.Watch(ctx, func(e lookout.Event) error {
+	err = w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		events++
 		return nil
 	})
@@ -103,7 +103,7 @@ func (s *WatcherTestSuite) TestWatch_WithError() {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
 	defer cancel()
 
-	err = w.Watch(ctx, func(e lookout.Event) error {
+	err = w.Watch(ctx, func(ctx context.Context, e lookout.Event) error {
 		s.Equal(pb.PushEventType, e.Type())
 		s.Equal("http://github.com/foo/bar", e.Revision().Base.InternalRepositoryURL)
 		return fmt.Errorf("foo")

--- a/server/server.go
+++ b/server/server.go
@@ -43,10 +43,7 @@ func (s *Server) Run(ctx context.Context) error {
 	errCh := make(chan error, 1)
 	for {
 		go func() {
-			// FIXME(max): we most probably want to change interface of EventHandler instead of it
-			err := s.watcher.Watch(ctx, func(e lookout.Event) error {
-				return s.handleEvent(ctx, e)
-			})
+			err := s.watcher.Watch(ctx, s.handleEvent)
 			errCh <- err
 		}()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -384,7 +384,7 @@ func (w *WatcherMock) Watch(ctx context.Context, e lookout.EventHandler) error {
 }
 
 func (w *WatcherMock) Send(e lookout.Event) error {
-	return w.handler(e)
+	return w.handler(context.Background(), e)
 }
 
 var _ lookout.Poster = &PosterMock{}

--- a/service/bblfsh/bblfsh.go
+++ b/service/bblfsh/bblfsh.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/ctxlog"
 
 	"google.golang.org/grpc"
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 	"gopkg.in/bblfsh/sdk.v1/uast"
-	log "gopkg.in/src-d/go-log.v1"
 )
 
 // Service implements data service interface which adds UAST to the responses
@@ -92,7 +92,7 @@ func (s *BaseScanner) processFile(f *lookout.File) error {
 		return nil
 	}
 
-	log.Debugf("parsing uast for file: %s", f.Path)
+	ctxlog.Get(s.ctx).Debugf("parsing uast for file: %s", f.Path)
 
 	var err error
 	f.UAST, err = s.parseFile(f)

--- a/service/git/library_test.go
+++ b/service/git/library_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestLibrary_Init(t *testing.T) {
 	url, _ := vcsurl.Parse("http://github.com/foo/bar")
 	library := NewLibrary(memfs.New())
 
-	r, err := library.Init(url)
+	r, err := library.Init(context.Background(), url)
 	require.NoError(err)
 	require.NotNil(r)
 
@@ -43,11 +44,11 @@ func TestLibrary_InitExists(t *testing.T) {
 	url, _ := vcsurl.Parse("http://github.com/foo/bar")
 	library := NewLibrary(memfs.New())
 
-	r, err := library.Init(url)
+	r, err := library.Init(context.Background(), url)
 	require.NoError(err)
 	require.NotNil(r)
 
-	r, err = library.Init(url)
+	r, err = library.Init(context.Background(), url)
 	require.True(ErrRepositoryExists.Is(err))
 	require.Nil(r)
 }
@@ -58,10 +59,10 @@ func TestLibrary_Get(t *testing.T) {
 	url, _ := vcsurl.Parse("http://github.com/foo/bar")
 	library := NewLibrary(memfs.New())
 
-	_, err := library.Init(url)
+	_, err := library.Init(context.Background(), url)
 	require.NoError(err)
 
-	r, err := library.Get(url)
+	r, err := library.Get(context.Background(), url)
 	require.NoError(err)
 	require.NotNil(r)
 }
@@ -72,11 +73,11 @@ func TestLibrary_GetOrInit(t *testing.T) {
 	url, _ := vcsurl.Parse("http://github.com/foo/bar")
 	library := NewLibrary(memfs.New())
 
-	r, err := library.GetOrInit(url)
+	r, err := library.GetOrInit(context.Background(), url)
 	require.NoError(err)
 	require.NotNil(r)
 
-	r, err = library.GetOrInit(url)
+	r, err = library.GetOrInit(context.Background(), url)
 	require.NoError(err)
 	require.NotNil(r)
 }

--- a/service/git/loader.go
+++ b/service/git/loader.go
@@ -48,7 +48,7 @@ func (l *LibraryCommitLoader) LoadCommits(
 		return nil, err
 	}
 
-	r, err := l.Library.GetOrInit(frp.Repository())
+	r, err := l.Library.GetOrInit(ctx, frp.Repository())
 	if err != nil {
 		return nil, err
 	}

--- a/service/git/scanner_test.go
+++ b/service/git/scanner_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -204,6 +205,7 @@ func (s *ScannerSuite) testFileFilterScannerFixture(fixture *lookout.FilesReques
 		require.NoError(err)
 
 		cs := NewFileFilterScanner(
+			context.Background(),
 			NewTreeScanner(headTree),
 			fixture.IncludePattern, fixture.ExcludePattern,
 		)
@@ -229,6 +231,7 @@ func (s *ScannerSuite) TestChangeBlobScanner() {
 	require.NoError(err)
 
 	cs := NewChangeBlobScanner(
+		context.Background(),
 		NewTreeScanner(headTree),
 		nil, headTree,
 	)
@@ -262,6 +265,7 @@ func (s *ScannerSuite) TestFileBlobScanner() {
 	require.NoError(err)
 
 	cs := NewFileBlobScanner(
+		context.Background(),
 		NewTreeScanner(headTree),
 		headTree,
 	)
@@ -340,7 +344,7 @@ func (s *ScannerSuite) TestFileExcludeVendorScanner() {
 	headTree, err := head.Tree()
 	require.NoError(err)
 
-	cs := NewFileExcludeVendorScanner(NewTreeScanner(headTree))
+	cs := NewFileExcludeVendorScanner(context.Background(), NewTreeScanner(headTree))
 
 	var files []*lookout.File
 	for cs.Next() {

--- a/service/git/syncer.go
+++ b/service/git/syncer.go
@@ -43,7 +43,7 @@ func (s *Syncer) Sync(ctx context.Context,
 		}
 	}
 
-	r, err := s.l.GetOrInit(frp.Repository())
+	r, err := s.l.GetOrInit(ctx, frp.Repository())
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (s *Syncer) Sync(ctx context.Context,
 		var rs config.RefSpec
 		if "" == rp.ReferenceName {
 			rs = config.RefSpec(fmt.Sprintf(config.DefaultFetchRefSpec, defaultRemoteName))
-			log.Warningf("empty ReferenceName given in %v, using default '%s' instead", rp, rs)
+			ctxlog.Get(ctx).Warningf("empty ReferenceName given in %v, using default '%s' instead", rp, rs)
 		} else {
 			rs = config.RefSpec(fmt.Sprintf("%s:%[1]s", rp.ReferenceName))
 		}

--- a/util/cli/common_options.go
+++ b/util/cli/common_options.go
@@ -8,6 +8,8 @@ type initializer interface {
 	init(*App)
 }
 
+var _ initializer = &CommonOptions{}
+
 // CommonOptions contains common flags for all commands
 type CommonOptions struct {
 	LogOptions

--- a/util/cli/log.go
+++ b/util/cli/log.go
@@ -14,8 +14,10 @@ type LogOptions struct {
 	Verbose        bool   `long:"verbose" short:"v" description:"enable verbose logging"`
 }
 
+var _ initializer = &LogOptions{}
+
 // Init initializes the default logger factory.
-func (c *LogOptions) init(app *App) error {
+func (c *LogOptions) init(app *App) {
 	if c.Verbose {
 		c.LogLevel = "debug"
 	}
@@ -29,6 +31,4 @@ func (c *LogOptions) init(app *App) error {
 	log.DefaultFactory.ApplyToLogrus()
 
 	log.DefaultLogger = log.New(log.Fields{"app": app.Name})
-
-	return nil
 }

--- a/util/ctxlog/context.go
+++ b/util/ctxlog/context.go
@@ -17,6 +17,9 @@ func Get(ctx context.Context) log.Logger {
 		return v.(log.Logger)
 	}
 
+	if log.DefaultLogger == nil {
+		log.DefaultLogger = log.New(nil)
+	}
 	return log.DefaultLogger
 }
 

--- a/watcher.go
+++ b/watcher.go
@@ -20,5 +20,5 @@ type Watcher interface {
 	Watch(context.Context, EventHandler) error
 }
 
-// EventHandler funciton to be called when a new event happends.
-type EventHandler func(Event) error
+// EventHandler is the function to be called when a new event happens.
+type EventHandler func(context.Context, Event) error


### PR DESCRIPTION
Fix #181.

The main change in this PR is that the callbacks with `EventHandler` accept the context, and keep the log fields like the PR number.

The `service/git` methods now get the log from the context, but the problem here is that the gRPC requests come from the analyzer, and we don't have the `event-id` or any other field.
I didn't look much into it, so I don't know if there is a way to pass some ID fields to the analyzer and get them back when they call `GetFiles/GetChanges` without modifying the `proto` messages.