### PR TITLE
Dynamic repos

### DIFF
--- a/cmd/lookoutd/serve.go
+++ b/cmd/lookoutd/serve.go
@@ -33,8 +33,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var installationsSyncInterval = time.Hour
-
 func init() {
 	if _, err := app.AddCommand("serve", "run server", "",
 		&ServeCommand{}); err != nil {
@@ -57,6 +55,8 @@ type ServeCommand struct {
 	analyzers map[string]lookout.AnalyzerClient
 	pool      *github.ClientPool
 }
+
+var defaultInstallationsSyncInterval = time.Hour
 
 // Config holds the main configuration
 type Config struct {
@@ -228,6 +228,14 @@ func (c *ServeCommand) initProviderGithubApp(conf Config) error {
 	}
 	if conf.Providers.Github.AppID == 0 {
 		return fmt.Errorf("missing GitHub App ID in config")
+	}
+	installationsSyncInterval := defaultInstallationsSyncInterval
+	if conf.Providers.Github.InstallationSyncInterval != "" {
+		var err error
+		installationsSyncInterval, err = time.ParseDuration(conf.Providers.Github.InstallationSyncInterval)
+		if err != nil {
+			return fmt.Errorf("can't parse sync interval: %s", err)
+		}
 	}
 
 	cache := cache.NewValidableCache(diskcache.New("/tmp/github"))

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -9,6 +9,7 @@ providers:
     # See https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
     # app_id: 1234
     # private_key: ./key.pem
+    # installation_sync_interval: 1h
 
 repositories:
   - url: github.com/src-d/lookout

--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -78,6 +78,9 @@ func (p *ClientPool) Client(username, repo string) (*Client, bool) {
 
 // Repos returns list of repositories in the pool
 func (p *ClientPool) Repos() []string {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	var rps []string
 	for r := range p.byRepo {
 		rps = append(rps, r)

--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -46,7 +46,7 @@ func NewClientPool() *ClientPool {
 	return &ClientPool{
 		byClients: make(map[*Client][]*lookout.RepositoryInfo),
 		byRepo:    make(map[string]*Client),
-		Changes:   make(chan ClientPoolEvent),
+		Changes:   make(chan ClientPoolEvent, 500), // add some reasonable buffer
 	}
 }
 

--- a/provider/github/client_test.go
+++ b/provider/github/client_test.go
@@ -1,0 +1,137 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/src-d/lookout"
+	"github.com/stretchr/testify/require"
+	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
+)
+
+func TestClientPoolUpdate(t *testing.T) {
+	require := require.New(t)
+
+	p := NewClientPool()
+	// read from channel to unblock it
+	go func() {
+		for _ = range p.Changes {
+		}
+	}()
+
+	// add new client
+	firstClient := &Client{}
+	info11, _ := vcsurl.Parse("github.com/foo/bar1")
+	info12, _ := vcsurl.Parse("github.com/foo/bar2")
+	firstClientRepos := []*lookout.RepositoryInfo{
+		info11,
+		info12,
+	}
+
+	p.Update(firstClient, firstClientRepos)
+
+	require.Len(p.Clients(), 1)
+
+	c, ok := p.Client("foo", "bar1")
+	require.True(ok)
+	require.Equal(firstClient, c)
+
+	c, ok = p.Client("foo", "bar2")
+	require.True(ok)
+	require.Equal(firstClient, c)
+
+	require.Equal(firstClientRepos, p.ReposByClient(firstClient))
+
+	// add one more client
+	secondClient := &Client{}
+	info21, _ := vcsurl.Parse("github.com/bar/foo1")
+	info22, _ := vcsurl.Parse("github.com/bar/foo2")
+	secondClientRepos := []*lookout.RepositoryInfo{
+		info21,
+		info22,
+	}
+
+	p.Update(secondClient, secondClientRepos)
+
+	require.Len(p.Clients(), 2)
+
+	c, ok = p.Client("bar", "foo1")
+	require.True(ok)
+	require.Equal(secondClient, c)
+
+	c, ok = p.Client("bar", "foo2")
+	require.True(ok)
+	require.Equal(secondClient, c)
+
+	require.Equal(secondClientRepos, p.ReposByClient(secondClient))
+
+	// add new repo
+	info13, _ := vcsurl.Parse("github.com/foo/bar3")
+	firstClientRepos = append(firstClientRepos, info13)
+
+	p.Update(firstClient, firstClientRepos)
+
+	require.Equal(firstClientRepos, p.ReposByClient(firstClient))
+
+	c, ok = p.Client("foo", "bar3")
+	require.True(ok)
+	require.Equal(firstClient, c)
+
+	// remove repo
+	firstClientRepos = []*lookout.RepositoryInfo{
+		info11,
+		info13,
+	}
+	p.Update(firstClient, firstClientRepos)
+
+	require.Equal(firstClientRepos, p.ReposByClient(firstClient))
+
+	_, ok = p.Client("foo", "bar2")
+	require.False(ok)
+
+	// remove client
+	p.RemoveClient(secondClient)
+
+	require.Len(p.Clients(), 1)
+	_, ok = p.Client("bar", "foo1")
+	require.False(ok)
+
+	// update without repos
+	p.Update(firstClient, []*lookout.RepositoryInfo{})
+	require.Len(p.Clients(), 0)
+
+	// update without repos once again
+	p.Update(firstClient, []*lookout.RepositoryInfo{})
+	require.Len(p.Clients(), 0)
+}
+
+func TestClientPoolMultipleDeleteRepos(t *testing.T) {
+	require := require.New(t)
+
+	p := NewClientPool()
+	// read from channel to unblock it
+	go func() {
+		for _ = range p.Changes {
+		}
+	}()
+
+	// add new client
+	client := &Client{}
+	info1, _ := vcsurl.Parse("github.com/foo/bar1")
+	info2, _ := vcsurl.Parse("github.com/foo/bar2")
+	info3, _ := vcsurl.Parse("github.com/foo/bar3")
+	repos := []*lookout.RepositoryInfo{
+		info1,
+		info2,
+		info3,
+	}
+
+	p.Update(client, repos)
+
+	require.Len(p.ReposByClient(client), 3)
+
+	// remove repos
+	newRepos := []*lookout.RepositoryInfo{info2}
+	p.Update(client, newRepos)
+
+	require.Equal(newRepos, p.ReposByClient(client))
+}

--- a/provider/github/client_test.go
+++ b/provider/github/client_test.go
@@ -12,11 +12,6 @@ func TestClientPoolUpdate(t *testing.T) {
 	require := require.New(t)
 
 	p := NewClientPool()
-	// read from channel to unblock it
-	go func() {
-		for _ = range p.Changes {
-		}
-	}()
 
 	// add new client
 	firstClient := &Client{}
@@ -108,11 +103,6 @@ func TestClientPoolMultipleDeleteRepos(t *testing.T) {
 	require := require.New(t)
 
 	p := NewClientPool()
-	// read from channel to unblock it
-	go func() {
-		for _ = range p.Changes {
-		}
-	}()
 
 	// add new client
 	client := &Client{}

--- a/provider/github/installations.go
+++ b/provider/github/installations.go
@@ -1,0 +1,149 @@
+package github
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bradleyfalzon/ghinstallation"
+	"github.com/google/go-github/github"
+	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/util/cache"
+	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+// Installations keeps github installations and allows to sync them
+type Installations struct {
+	appID      int
+	privateKey string
+	appClient  *github.Client
+
+	// FIXME can we get rid of it here?
+	cache *cache.ValidableCache
+
+	// [installationID]installationClient
+	clients map[int64]*Client
+
+	Pool *ClientPool
+}
+
+// NewInstallations creates a new Installations using the App ID and private key
+func NewInstallations(appID int, privateKey string, cache *cache.ValidableCache) (*Installations, error) {
+	// Use App authorization to list installations
+	appTr, err := ghinstallation.NewAppsTransportKeyFromFile(
+		http.DefaultTransport, appID, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	appClient := github.NewClient(&http.Client{Transport: appTr})
+	app, _, err := appClient.Apps.Get(context.TODO(), "")
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("authorized as GitHub application %q, ID %v", app.GetName(), app.GetID())
+
+	i := &Installations{
+		appID:      appID,
+		privateKey: privateKey,
+		appClient:  appClient,
+		cache:      cache,
+		clients:    make(map[int64]*Client),
+		Pool:       NewClientPool(),
+	}
+
+	return i, nil
+}
+
+// Sync update state from github
+func (t *Installations) Sync() error {
+	log.Infof("syncing installations with github")
+
+	installations, _, err := t.appClient.Apps.ListInstallations(context.TODO(), &github.ListOptions{})
+	if err != nil {
+		return err
+	}
+	log.Debugf("found %d installations", len(installations))
+
+	new := make(map[int64]*github.Installation, len(installations))
+	for _, installation := range installations {
+		new[installation.GetID()] = installation
+	}
+
+	// remove revoked installations
+	for id := range t.clients {
+		if _, ok := new[id]; !ok {
+			log.Debugf("remove installation %d", id)
+			t.removeInstallation(id)
+		}
+	}
+
+	// add new installations
+	for id := range new {
+		if _, ok := t.clients[id]; !ok {
+			log.Debugf("add installation %d", id)
+			t.addInstallation(id)
+		}
+	}
+
+	// sync repos for all available installations
+	for id, c := range t.clients {
+		repos, err := t.getRepos(c)
+		if err != nil {
+			return err
+		}
+		log.Debugf("%d repositories found for installation %d", len(repos), id)
+		t.Pool.Update(c, repos)
+	}
+
+	return nil
+}
+
+func (t *Installations) addInstallation(id int64) error {
+	c, err := t.createClient(id)
+	if err != nil {
+		return err
+	}
+
+	t.clients[id] = c
+
+	return nil
+}
+
+func (t *Installations) removeInstallation(id int64) {
+	t.Pool.RemoveClient(t.clients[id])
+
+	delete(t.clients, id)
+}
+
+func (t *Installations) createClient(installationID int64) (*Client, error) {
+	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport,
+		t.appID, int(installationID), t.privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO (carlosms): hardcoded, take from config
+	watchMinInterval := ""
+	return NewClient(itr, t.cache, log.DefaultLogger, watchMinInterval), nil
+}
+
+func (t *Installations) getRepos(iClient *Client) ([]*lookout.RepositoryInfo, error) {
+	ghRepos, _, err := iClient.Apps.ListRepos(context.TODO(), &github.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	repos := make([]*lookout.RepositoryInfo, len(ghRepos))
+	for i, ghRepo := range ghRepos {
+		repo, err := vcsurl.Parse(*ghRepo.HTMLURL)
+		if err != nil {
+			return nil, err
+		}
+
+		repos[i] = repo
+	}
+
+	return repos, nil
+}

--- a/provider/github/installations.go
+++ b/provider/github/installations.go
@@ -18,7 +18,6 @@ type Installations struct {
 	privateKey string
 	appClient  *github.Client
 
-	// FIXME can we get rid of it here?
 	cache *cache.ValidableCache
 
 	// [installationID]installationClient

--- a/provider/github/installations.go
+++ b/provider/github/installations.go
@@ -126,7 +126,7 @@ func (t *Installations) createClient(installationID int64) (*Client, error) {
 
 	// TODO (carlosms): hardcoded, take from config
 	watchMinInterval := ""
-	return NewClient(itr, t.cache, log.DefaultLogger, watchMinInterval), nil
+	return NewClient(itr, t.cache, watchMinInterval), nil
 }
 
 func (t *Installations) getRepos(iClient *Client) ([]*lookout.RepositoryInfo, error) {

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -1,16 +1,12 @@
 package github
 
 import (
-	"context"
 	"net/http"
-	"strings"
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/util/cache"
 	"github.com/src-d/lookout/util/ctxlog"
 
-	"github.com/bradleyfalzon/ghinstallation"
-	"github.com/google/go-github/github"
 	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
 	log "gopkg.in/src-d/go-log.v1"
 )
@@ -60,83 +56,6 @@ func NewClientPoolFromTokens(urlToConfig map[string]ClientConfig, cache *cache.V
 			byRepo[r.FullName] = client
 		}
 	}
-
-	pool := &ClientPool{
-		byClients: byClients,
-		byRepo:    byRepo,
-	}
-	return pool, nil
-}
-
-// NewClientPoolInstallations creates a new ClientPool using the App ID and
-// private key set in providerConf
-func NewClientPoolInstallations(
-	cache *cache.ValidableCache,
-	providerConf ProviderConfig,
-) (*ClientPool, error) {
-	// Use App authorization to list installations
-	appTr, err := ghinstallation.NewAppsTransportKeyFromFile(
-		http.DefaultTransport, providerConf.AppID, providerConf.PrivateKey)
-	if err != nil {
-		return nil, err
-	}
-
-	appClient := github.NewClient(&http.Client{Transport: appTr})
-	app, _, err := appClient.Apps.Get(context.TODO(), "")
-	if err != nil {
-		return nil, err
-	}
-
-	log.Infof("authorized as GitHub application %q, ID %v", app.GetName(), app.GetID())
-
-	installations, _, err := appClient.Apps.ListInstallations(context.TODO(), &github.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	byClients := make(map[*Client][]*lookout.RepositoryInfo, len(installations))
-	byRepo := make(map[string]*Client)
-	allRepos := make([]string, 0)
-
-	// Create a client for each installation, assign it to its repos
-	for _, installation := range installations {
-		installationID := int(installation.GetID())
-
-		itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport,
-			providerConf.AppID, installationID, providerConf.PrivateKey)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO (carlosms): hardcoded, take from config
-		watchMinInterval := ""
-		iClient := NewClient(itr, cache, watchMinInterval)
-
-		ghRepos, _, err := iClient.Apps.ListRepos(context.TODO(), &github.ListOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		repos := make([]*lookout.RepositoryInfo, len(ghRepos))
-
-		for i, ghRepo := range ghRepos {
-			log.Debugf("installation %v has repo %s", installationID, *ghRepo.HTMLURL)
-
-			repo, err := vcsurl.Parse(*ghRepo.HTMLURL)
-			if err != nil {
-				return nil, err
-			}
-
-			repos[i] = repo
-			byRepo[repo.FullName] = iClient
-			allRepos = append(allRepos, repo.FullName)
-		}
-
-		byClients[iClient] = repos
-	}
-
-	log.Infof("found %v repositories using the GitHub application: %v",
-		len(allRepos), strings.Join(allRepos, ","))
 
 	pool := &ClientPool{
 		byClients: byClients,

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -77,11 +77,14 @@ func (w *Watcher) Watch(ctx context.Context, cb lookout.EventHandler) error {
 }
 
 func (w *Watcher) listenForChanges(ctx context.Context, cb lookout.EventHandler, errCh chan error) {
+	ch := make(chan ClientPoolEvent)
+	w.pool.Subscribe(ch)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case change := <-w.pool.Changes:
+		case change := <-ch:
 			ctxlog.Get(ctx).
 				With(log.Fields{"type": change.Type}).
 				Debugf("New event from the client pool")

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -18,9 +18,10 @@ const Provider = "github"
 
 // ProviderConfig represents the yml config
 type ProviderConfig struct {
-	CommentFooter string `yaml:"comment_footer"`
-	PrivateKey    string `yaml:"private_key"`
-	AppID         int    `yaml:"app_id"`
+	CommentFooter            string `yaml:"comment_footer"`
+	PrivateKey               string `yaml:"private_key"`
+	AppID                    int    `yaml:"app_id"`
+	InstallationSyncInterval string `yaml:"installation_sync_interval"`
 }
 
 // don't call github more often than

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -344,7 +344,7 @@ func (s *WatcherTestSuite) TestAddRepo() {
 		w.pool.Update(c, append(w.pool.ReposByClient(c), repo))
 	}()
 
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(context.Context, lookout.Event) error {
 		return nil
 	})
 
@@ -379,7 +379,7 @@ func (s *WatcherTestSuite) TestRemoveRepo() {
 		w.pool.Update(c, repos)
 	}()
 
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(context.Context, lookout.Event) error {
 		return nil
 	})
 
@@ -409,7 +409,7 @@ func (s *WatcherTestSuite) TestAddClient() {
 		w.pool.Update(c, []*lookout.RepositoryInfo{repo})
 	}()
 
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(context.Context, lookout.Event) error {
 		return nil
 	})
 
@@ -458,7 +458,7 @@ func (s *WatcherTestSuite) TestRemoveClient() {
 		pool.RemoveClient(client2)
 	}()
 
-	err := w.Watch(ctx, func(e lookout.Event) error {
+	err := w.Watch(ctx, func(context.Context, lookout.Event) error {
 		return nil
 	})
 

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -450,7 +450,7 @@ func (s *WatcherTestSuite) TestRemoveClient() {
 		byRepo:    byRepo,
 	}
 
-	w, _ := NewWatcher(pool, &lookout.WatchOptions{})
+	w, _ := NewWatcher(pool)
 
 	// remove client
 	go func() {

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -303,11 +303,11 @@ func (s *WatcherTestSuite) TestCustomMinInterval() {
 	repo, _ := vcsurl.Parse("github.com/mock/test")
 
 	pool := &ClientPool{
-		Changes: make(chan ClientPoolEvent),
 		byClients: map[*Client][]*lookout.RepositoryInfo{
 			client: []*lookout.RepositoryInfo{repo},
 		},
 		byRepo: map[string]*Client{"mock/test": client},
+		subs:   make(map[chan ClientPoolEvent]bool),
 	}
 
 	w, err := NewWatcher(pool)
@@ -445,9 +445,9 @@ func (s *WatcherTestSuite) TestRemoveClient() {
 	}
 
 	pool := &ClientPool{
-		Changes:   make(chan ClientPoolEvent),
 		byClients: byClients,
 		byRepo:    byRepo,
+		subs:      make(map[chan ClientPoolEvent]bool),
 	}
 
 	w, _ := NewWatcher(pool)
@@ -506,8 +506,8 @@ func newTestPool(s suite.Suite, repoURLs []string, githubURL *url.URL, cache *ca
 	}
 
 	return &ClientPool{
-		Changes:   make(chan ClientPoolEvent),
 		byClients: byClients,
 		byRepo:    byRepo,
+		subs:      make(map[chan ClientPoolEvent]bool),
 	}
 }

--- a/provider/github/watcher_test.go
+++ b/provider/github/watcher_test.go
@@ -383,9 +383,9 @@ func (s *WatcherTestSuite) TestRemoveRepo() {
 		return nil
 	})
 
-	fmt.Println(atomic.LoadInt32(&callsA), atomic.LoadInt32(&callsB))
-	s.True(atomic.LoadInt32(&callsA) > 2)
-	s.True(atomic.LoadInt32(&callsB) > 2)
+	s.True(atomic.LoadInt32(&callsA) > 10) // check that watching didn't stop
+	s.True(atomic.LoadInt32(&callsB) > 2)  // check that calls were made
+	s.True(atomic.LoadInt32(&callsB) < 10) // check that watching did stop
 	s.EqualError(err, "context deadline exceeded")
 }
 


### PR DESCRIPTION
Fix: #227 

- `ClientPool` isn't static anymore. Now it has `Update` and `RemoveClient` methods.
- `Watcher` now listens to the `ClientPool` changes and starts/stops goroutines.
- `Watcher` was refactored a little to remove `getClient` methods which would cause race conditions.
- New struct `Installations` holds a list of clients and syncs it with github