### PR TITLE
Change max length in go-metalinter-analyzer

### DIFF
--- a/.lookout.yml
+++ b/.lookout.yml
@@ -1,3 +1,7 @@
 analyzers:
   - name: Dummy
     disabled: true
+    settings:
+      linters:
+        - name: lll
+          maxLen: 120


### PR DESCRIPTION
I redeployed metalinter analyzer. This configuration should (hopefully) work now.