### PR TITLE
Apply same fields to all loggers

### DIFF
--- a/util/cli/log.go
+++ b/util/cli/log.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"encoding/json"
+
 	"gopkg.in/src-d/go-log.v1"
 )
 
@@ -22,6 +24,14 @@ func (c *LogOptions) init(app *App) {
 		c.LogLevel = "debug"
 	}
 
+	if c.LogFields == "" {
+		bytes, err := json.Marshal(log.Fields{"app": app.Name})
+		if err != nil {
+			panic(err)
+		}
+		c.LogFields = string(bytes)
+	}
+
 	log.DefaultFactory = &log.LoggerFactory{
 		Level:       c.LogLevel,
 		Format:      c.LogFormat,
@@ -30,5 +40,5 @@ func (c *LogOptions) init(app *App) {
 	}
 	log.DefaultFactory.ApplyToLogrus()
 
-	log.DefaultLogger = log.New(log.Fields{"app": app.Name})
+	log.DefaultLogger = log.New(nil)
 }


### PR DESCRIPTION
Part of #181. Fixes inconsistent log fields depending on the log method used.

With the code we have in master we have different log fields for the `DefaultLogger` and the `DefaultFactory`. These scenarios happen:

```go
log.Infof("msg")
// field "app"

log.With(log.Fields{"f": "txt"}).Infof("msg")
// field "f"

log.DefaultLogger.With(log.Fields{"f": "txt"}).Infof("msg")
// fields "f" and "app"
```