### PR TITLE
Fix client pool map initialization

### DIFF
--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -51,6 +51,19 @@ func NewClientPool() *ClientPool {
 	}
 }
 
+// newClientPoolFromClients creates a new pool of clients based on the given
+// clients and repositories
+func newClientPoolFromClients(
+	byClients map[*Client][]*lookout.RepositoryInfo,
+	byRepo map[string]*Client) *ClientPool {
+
+	return &ClientPool{
+		byClients: byClients,
+		byRepo:    byRepo,
+		subs:      make(map[chan ClientPoolEvent]bool),
+	}
+}
+
 // Clients returns map[Client]RepositoryInfo
 func (p *ClientPool) Clients() map[*Client][]*lookout.RepositoryInfo {
 	p.mutex.Lock()

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -57,10 +57,7 @@ func NewClientPoolFromTokens(urlToConfig map[string]ClientConfig, cache *cache.V
 		}
 	}
 
-	pool := &ClientPool{
-		byClients: byClients,
-		byRepo:    byRepo,
-	}
+	pool := newClientPoolFromClients(byClients, byRepo)
 	return pool, nil
 }
 


### PR DESCRIPTION
Fix #262.
`subs` was never initialized in `NewClientPoolFromTokens`.