### PR TITLE
Fix filter scanner for deleted files

### DIFF
--- a/service/git/scanner.go
+++ b/service/git/scanner.go
@@ -171,6 +171,10 @@ func (s *regexpFilter) OnStart() error {
 }
 
 func (s *regexpFilter) Fn(f *lookout.File) (bool, error) {
+	if f == nil {
+		return true, nil
+	}
+
 	if !s.matchInclude(f.Path) {
 		return true, nil
 	}


### PR DESCRIPTION
Fix #261.

File can be nil when the changes include a deleted file.