### PR TITLE
.lookout.yml configures dummy instead of gometalint

### DIFF
--- a/.lookout.yml
+++ b/.lookout.yml
@@ -1,6 +1,7 @@
 analyzers:
   - name: Dummy
     disabled: true
+  - name: gometalint-analyzer
     settings:
       linters:
         - name: lll


### PR DESCRIPTION
Part of #258

Not sure how it happened. Incorrect rebase/merge maybe?