### PR TITLE
Configure sonarcheck-analyzer on staging

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -30,3 +30,6 @@ analyzers:
   - name: gometalint-analyzer
     addr: ipv4://lookout-gometalint-analyzer:10303
     feedback: https://github.com/src-d/lookout-gometalint-analyzer/issues/new
+  - name: sonarcheck-analyzer
+    addr: ipv4://lookout-sonarcheck-analyzer:10304
+    feedback: https://github.com/src-d/lookout-sonarcheck-analyzer/issues/new


### PR DESCRIPTION
Now, that https://github.com/src-d/lookout-sonarcheck-analyzer/releases/tag/v0.0.1 has been released it's time to enable it on staging.

Part of the #140