### PR TITLE
HOTFIX: add path to pk from secret on staging

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -19,7 +19,7 @@ repositories:
 providers:
   github:
     app_id: 17877
-    private_key: private-key.pem
+    private_key: /local/lookout/private-key.pem
     secretName: lookout-staging-github-key
     comment_footer: "_If you have feedback about this comment, please, [tell us](%s)._"
 


### PR DESCRIPTION
Part of the https://github.com/src-d/issues-infrastructure/issues/242#issuecomment-424430053

Otherwise, CD to staging fails with

```
{"app":"lookoutd","level":"info","msg":"connection with the DB established","source":"lookoutd/serve.go:407","time":"2018-09-25T16:55:37.069649857Z"}
could not read private key: open private-key.pem: no such file or directory
```