### PR TITLE
Remove repo arg from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "10301:10301"
     entrypoint: ["/bin/sh"]
     # sleep because container with db is up but the db itself doesn't accept connections yet
-    command: ["-c", "sleep 5 && lookoutd migrate && lookoutd serve ${REPO}"]
+    command: ["-c", "sleep 5 && lookoutd migrate && lookoutd serve"]
     volumes:
       - ./config.yml:/config.yml
   dummy:


### PR DESCRIPTION
Unsupported `serve` arg for repo was not removed from the docker compose file.