### PR TITLE
Use a fixed bblfsh version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       script: make test-coverage codecov
     - name: 'SDK Integration Tests Linux'
       script:
-        - docker run -d --name bblfshd --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
+        - docker run -d --name bblfshd --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd:v2.7.2
         - docker exec -it bblfshd bblfshctl driver install go bblfsh/go-driver:v2.2.0
         - make test-sdk
     - name: 'SDK Integration Tests macOS'


### PR DESCRIPTION
Travis is failing on master because of https://github.com/bblfsh/bblfshd/issues/195.