### PR TITLE
Include regexp patterns in dummy requests

### DIFF
--- a/dummy/dummy.go
+++ b/dummy/dummy.go
@@ -24,10 +24,12 @@ func (a *Analyzer) NotifyReviewEvent(ctx context.Context, e *lookout.ReviewEvent
 	*lookout.EventResponse, error) {
 
 	changes, err := a.DataClient.GetChanges(ctx, &lookout.ChangesRequest{
-		Base:         &e.CommitRevision.Base,
-		Head:         &e.CommitRevision.Head,
-		WantContents: true,
-		WantUAST:     a.RequestUAST,
+		Base:           &e.CommitRevision.Base,
+		Head:           &e.CommitRevision.Head,
+		WantContents:   true,
+		WantUAST:       a.RequestUAST,
+		IncludePattern: ".*",
+		ExcludePattern: "^should-never-match$",
 	})
 	if err != nil {
 		return nil, err
@@ -62,6 +64,8 @@ func (a *Analyzer) NotifyPushEvent(ctx context.Context, e *lookout.PushEvent) (*
 		ExcludeVendored: true,
 		WantContents:    true,
 		WantUAST:        a.RequestUAST,
+		IncludePattern:  ".*",
+		ExcludePattern:  "^should-never-match$",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
While testing #304 I added regexp to each requests made by the dummy analyzer.
These should not have any impact on the results, but it will help to uncover big problems like #261 in our integration tests.