### PR TITLE
Update to bblfsh 2.9, use -drivers image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ jobs:
       script: make test-coverage codecov
     - name: 'SDK Integration Tests Linux'
       script:
-        - docker run -d --name bblfshd --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd:v2.7.2
-        - docker exec -it bblfshd bblfshctl driver install go bblfsh/go-driver:v2.2.0
+        - docker run -d --name bblfshd --privileged -v $HOME/bblfshd:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd:v2.9.0
+        - docker exec -it bblfshd bblfshctl driver install --force go bblfsh/go-driver:v2.2.0
         - make test-sdk
     - name: 'SDK Integration Tests macOS'
       if: NOT type = pull_request

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,18 +23,10 @@ services:
     ports:
       - "10302:10302"
   bblfsh:
-    image: "bblfsh/bblfshd:v2.7.2"
+    image: "bblfsh/bblfshd:v2.9.0-drivers"
     privileged: true
     ports:
       - "9432:9432"
-    volumes:
-      - type: volume
-        source: drivers
-        target: /var/lib/bblfshd
-    entrypoint: ["/bin/sh"]
-    command:
-    - "-c"
-    - "bblfshd & sleep 1 && bblfshctl driver install --recommended && tail -f /dev/null"
   postgres:
     image: "postgres:alpine"
     restart: always
@@ -43,5 +35,3 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: lookout
-volumes:
-  drivers:


### PR DESCRIPTION
Use bblfsh `-drivers` image in docker-compose, update travis bblfsh to 2.9.