### PR TITLE
Concurrent queue job processing - redone

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -723,7 +723,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:81e67057a8a099050b28dae9eaa390d29cdb5e266d84271366c30314c0e93e6a"
+  digest = "1:30a3b11284f8d5d7cd70b69ce248b3b1be42d60925f890041bd8053aa4e84b57"
   name = "gopkg.in/src-d/go-queue.v1"
   packages = [
     ".",
@@ -731,8 +731,8 @@
     "memory",
   ]
   pruneopts = "NUT"
-  revision = "6214d25507193fb3f3f011d29ed75cee98bd84b0"
-  version = "v1.0.4"
+  revision = "a66740343c2e86af43071508783c16b9c5f92319"
+  version = "v1.0.5"
 
 [[projects]]
   digest = "1:e532b733db09e0d561bd3d10a3c50198234aee2ff289211f3c1f6f44d9aeaf1f"
@@ -796,7 +796,6 @@
     "github.com/jessevdk/go-flags",
     "github.com/jinzhu/copier",
     "github.com/lib/pq",
-    "github.com/pkg/errors",
     "github.com/sanity-io/litter",
     "github.com/satori/go.uuid",
     "github.com/src-d/lookout-test-fixtures",

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -29,3 +29,10 @@ The `lookoutd watch` and `work` subcommands accept the following options to conf
 | -- | -- | -- | -- |
 | `LOOKOUT_QUEUE`  | `--queue=`  | queue name | `lookout` |
 | `LOOKOUT_BROKER` | `--broker=` | broker service URI | `amqp://localhost:5672` |
+
+You can also adjust the number of events that each _worker_ will process concurrently:
+
+| Env var | Option | Description | Default |
+| -- | -- | -- | -- |
+| `LOOKOUT_WORKERS` | `--workers=` | number of concurrent workers processing events, 0 means the same number as processors | 1  |
+

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -9,7 +9,6 @@ import (
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/util/ctxlog"
 
-	"github.com/pkg/errors"
 	"gopkg.in/src-d/go-queue.v1"
 	_ "gopkg.in/src-d/go-queue.v1/amqp"
 	_ "gopkg.in/src-d/go-queue.v1/memory"
@@ -50,16 +49,8 @@ func (j QueueJob) Event() (lookout.Event, error) {
 		return j.ReviewEvent, nil
 	}
 
-	return nil, errors.New("queue does not contain a valid lookout event")
+	return nil, fmt.Errorf("queue does not contain a valid lookout event")
 }
-
-// queueWindow defines the maximum number of unacknowledged jobs that the
-// queue iterator will allow to retrieve. A number of 1 will mean that each
-// job is processed sequentially
-// TODO(carlosms): because the eventHandler is called synchronously, a value
-// greater than 1 will not have any effect for now. We will not call iter.Next()
-// until the previous job is acknowledged or rejected
-const queueWindow = 1
 
 // EventEnqueuer returns an event handler that pushes events to the queue.
 func EventEnqueuer(ctx context.Context, q queue.Queue) lookout.EventHandler {
@@ -85,13 +76,22 @@ func EventEnqueuer(ctx context.Context, q queue.Queue) lookout.EventHandler {
 	}
 }
 
-// RunEventDequeuer starts a loop that takes jobs from the queue as they become
-// available, and calls the given event handler. The handler call is synchronous,
-// the next job will not be retrieved until the callback handler is finished with
-func RunEventDequeuer(ctx context.Context, q queue.Queue, eventHandler lookout.EventHandler) error {
-	iter, err := q.Consume(queueWindow)
+// RunEventDequeuer starts an infinite loop that takes jobs from the queue as
+// they become available. Concurrent determines the maximum number of goroutines
+// used to call the given event handler.
+func RunEventDequeuer(
+	ctx context.Context,
+	q queue.Queue,
+	eventHandler lookout.EventHandler,
+	concurrent int,
+) error {
+	if concurrent < 1 {
+		return fmt.Errorf("wrong value %v for concurrent argument", concurrent)
+	}
+
+	iter, err := q.Consume(concurrent)
 	if err != nil {
-		return errors.Wrap(err, "queue consume failed")
+		return fmt.Errorf("queue consume failed: %s", err.Error())
 	}
 
 	defer func() {
@@ -103,36 +103,38 @@ func RunEventDequeuer(ctx context.Context, q queue.Queue, eventHandler lookout.E
 	for {
 		consumedJob, err := iter.Next()
 		if err != nil {
-			return errors.Wrap(err, "queue iterator failed")
+			return fmt.Errorf("queue iterator failed: %s", err.Error())
 		}
 
 		if consumedJob == nil {
-			ctxlog.Get(ctx).Warningf("consumedJob should not be nil, bug in memory queue?")
+			ctxlog.Get(ctx).Warningf("consumedJob is not expected to be nil")
 			time.Sleep(1 * time.Second)
 			continue
 		}
 
-		var qJob QueueJob
-		if err = consumedJob.Decode(&qJob); err != nil {
-			ctxlog.Get(ctx).Errorf(err, "job decode failed")
-			consumedJob.Reject(false)
-			continue
-		}
+		go func(consumedJob *queue.Job) {
+			var qJob QueueJob
+			if err = consumedJob.Decode(&qJob); err != nil {
+				ctxlog.Get(ctx).Errorf(err, "job decode failed")
+				consumedJob.Reject(false)
+				return
+			}
 
-		event, err := qJob.Event()
-		if err != nil {
-			ctxlog.Get(ctx).Errorf(err, "error handling the queue job")
-			consumedJob.Reject(false)
-			continue
-		}
+			event, err := qJob.Event()
+			if err != nil {
+				ctxlog.Get(ctx).Errorf(err, "error handling the queue job")
+				consumedJob.Reject(false)
+				return
+			}
 
-		err = eventHandler(ctx, event)
-		if err != nil {
-			ctxlog.Get(ctx).Errorf(err, "error handling the queue job")
-			consumedJob.Reject(true)
-			continue
-		}
+			err = eventHandler(ctx, event)
+			if err != nil {
+				ctxlog.Get(ctx).Errorf(err, "error handling the queue job")
+				consumedJob.Reject(true)
+				return
+			}
 
-		consumedJob.Ack()
+			consumedJob.Ack()
+		}(consumedJob)
 	}
 }


### PR DESCRIPTION
Part of #267.

Replaces #321, using the new advertized window support added to go-queue (https://github.com/src-d/go-queue/pull/16).