### PR TITLE
Fix integration tests erratic failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ bindata:
 		-modtime 1 \
 		$(MIGRATIONS_PATH)/...
 
-GOTEST_INTEGRATION = $(GOTEST) -tags=integration
+GOTEST_INTEGRATION = $(GOTEST) -parallel 1 -race -tags=integration
 
 # Integration test for sdk client
 .PHONY: test-sdk

--- a/cmd/server-test/dummy_analyzer_test.go
+++ b/cmd/server-test/dummy_analyzer_test.go
@@ -4,6 +4,7 @@ package server_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/src-d/lookout"
 	fixtures "github.com/src-d/lookout-test-fixtures"
@@ -20,12 +21,16 @@ func (suite *DummyIntegrationSuite) SetupTest() {
 	suite.ResetDB()
 
 	suite.StoppableCtx()
-	suite.StartDummy("--files")
-
 	suite.r, suite.w = suite.StartLookoutd(dummyConfigFile)
+
+	suite.StartDummy("--files")
+	suite.GrepTrue(suite.r, `connection state changed to 'READY'`)
 }
 
 func (suite *DummyIntegrationSuite) TearDownTest() {
+	// TODO: for integration tests with RabbitMQ we wait a bit so the queue
+	// is depleted. Ideally this would be done with something similar to ResetDB
+	time.Sleep(5 * time.Second)
 	suite.Stop()
 }
 

--- a/cmd/server-test/dummy_analyzer_test.go
+++ b/cmd/server-test/dummy_analyzer_test.go
@@ -36,9 +36,11 @@ func (suite *DummyIntegrationSuite) TearDownTest() {
 
 func (suite *DummyIntegrationSuite) TestSuccessReview() {
 	suite.sendEvent(successJSON)
-	suite.GrepTrue(suite.r, "processing pull request")
-	suite.GrepTrue(suite.r, `{"analyzer-name":"Dummy","file":"another.go","line":3,"text":"This line exceeded`)
-	suite.GrepTrue(suite.r, `status=success`)
+	suite.GrepAll(suite.r, []string{
+		`processing pull request`,
+		`{"analyzer-name":"Dummy","file":"another.go","line":3,"text":"This line exceeded`,
+		`status=success`,
+	})
 }
 
 func (suite *DummyIntegrationSuite) TestReviewDontPostSameComment() {
@@ -53,8 +55,10 @@ func (suite *DummyIntegrationSuite) TestReviewDontPostSameComment() {
 	}
 
 	suite.sendEvent(rev0Event.String())
-	suite.GrepTrue(suite.r, `{"analyzer-name":"Dummy","file":"dummy.go","line":5,"text":"This line exceeded`)
-	suite.GrepTrue(suite.r, `status=success`)
+	suite.GrepAll(suite.r, []string{
+		`{"analyzer-name":"Dummy","file":"dummy.go","line":5,"text":"This line exceeded`,
+		`status=success`,
+	})
 
 	rev1Event := &jsonReviewEvent{
 		ReviewEvent: &lookout.ReviewEvent{
@@ -65,22 +69,14 @@ func (suite *DummyIntegrationSuite) TestReviewDontPostSameComment() {
 	}
 
 	suite.sendEvent(rev1Event.String())
-	suite.GrepTrue(suite.r, "processing pull request")
-
-	found, buf := suite.Grep(suite.r, `status=success`)
-	suite.Require().Truef(found, "'%s' not found in:\n%s", `status=success`, buf.String())
-
-	st := buf.String()
-
-	suite.Require().Contains(
-		st,
-		`{"analyzer-name":"Dummy","file":"dummy.go","text":"The file has increased`,
-	)
-
-	suite.Require().NotContains(
-		st,
-		`{"analyzer-name":"Dummy","file":"dummy.go","line":5,"text":"This line exceeded`,
-	)
+	suite.GrepAndNotAll(suite.r,
+		[]string{
+			`processing pull request`,
+			`{"analyzer-name":"Dummy","file":"dummy.go","text":"The file has increased`,
+			`status=success`,
+		}, []string{
+			`{"analyzer-name":"Dummy","file":"dummy.go","line":5,"text":"This line exceeded`,
+		})
 }
 
 func (suite *DummyIntegrationSuite) TestWrongRevision() {
@@ -107,9 +103,11 @@ func (suite *DummyIntegrationSuite) TestSuccessPush() {
 		},
 	}
 	suite.sendEvent(pushEvent.String())
-	suite.GrepTrue(suite.r, "processing push")
-	suite.GrepTrue(suite.r, "comments can belong only to review event but 1 is given")
-	suite.GrepTrue(suite.r, `status=success`)
+	suite.GrepAll(suite.r, []string{
+		"processing push",
+		"comments can belong only to review event but 1 is given",
+		`status=success`,
+	})
 }
 
 func TestDummyIntegrationSuite(t *testing.T) {

--- a/cmd/server-test/error_analyzer_test.go
+++ b/cmd/server-test/error_analyzer_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/util/grpchelper"
@@ -54,12 +55,16 @@ func (suite *ErrorAnalyzerIntegrationSuite) SetupTest() {
 	suite.ResetDB()
 
 	suite.StoppableCtx()
-	suite.startAnalyzer(suite.Ctx, &errAnalyzer{})
-
 	suite.r, suite.w = suite.StartLookoutd(dummyConfigFile)
+
+	suite.startAnalyzer(suite.Ctx, &errAnalyzer{})
+	suite.GrepTrue(suite.r, `connection state changed to 'READY'`)
 }
 
 func (suite *ErrorAnalyzerIntegrationSuite) TearDownTest() {
+	// TODO: for integration tests with RabbitMQ we wait a bit so the queue
+	// is depleted. Ideally this would be done with something similar to ResetDB
+	time.Sleep(5 * time.Second)
 	suite.Stop()
 }
 

--- a/cmd/server-test/multi_analyzer_test.go
+++ b/cmd/server-test/multi_analyzer_test.go
@@ -3,7 +3,6 @@
 package server_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -38,24 +37,14 @@ func (suite *MultiDummyIntegrationSuite) TearDownTest() {
 
 func (suite *MultiDummyIntegrationSuite) TestSuccessReview() {
 	suite.sendEvent(successJSON)
-	suite.GrepTrue(suite.r, "processing pull request")
-	suite.GrepTrue(suite.r, "posting analysis")
-	found, buf := suite.Grep(suite.r, `status=success`)
-	suite.Require().Truef(found, "'%s' not found in:\n%s", `status=success`, buf.String())
 
-	st := buf.String()
-
-	suite.Require().Contains(
-		st,
+	suite.GrepAll(suite.r, []string{
+		"processing pull request",
+		"posting analysis",
 		`{"analyzer-name":"Dummy1","file":"another.go","line":3,"text":"This line exceeded`,
-		fmt.Sprintf("no comments from the first analyzer from %s in '%s'", doubleDummyConfigFile, buf),
-	)
-
-	suite.Require().Contains(
-		st,
 		`{"analyzer-name":"Dummy2","file":"another.go","line":3,"text":"This line exceeded`,
-		fmt.Sprintf("no comments from the second analyzer from %s in '%s'", doubleDummyConfigFile, buf),
-	)
+		`status=success`,
+	})
 }
 
 func TestMultiDummyIntegrationSuite(t *testing.T) {

--- a/cmd/server-test/multi_analyzer_test.go
+++ b/cmd/server-test/multi_analyzer_test.go
@@ -5,6 +5,7 @@ package server_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -19,13 +20,19 @@ func (suite *MultiDummyIntegrationSuite) SetupTest() {
 	suite.ResetDB()
 
 	suite.StoppableCtx()
-	suite.StartDummy("--files")
-	suite.StartDummy("--files", "--analyzer", "ipv4://localhost:10303")
-
 	suite.r, suite.w = suite.StartLookoutd(doubleDummyConfigFile)
+
+	suite.StartDummy("--files")
+	suite.GrepTrue(suite.r, `connection state changed to 'READY'`)
+
+	suite.StartDummy("--files", "--analyzer", "ipv4://localhost:10303")
+	suite.GrepTrue(suite.r, `connection state changed to 'READY'`)
 }
 
 func (suite *MultiDummyIntegrationSuite) TearDownTest() {
+	// TODO: for integration tests with RabbitMQ we wait a bit so the queue
+	// is depleted. Ideally this would be done with something similar to ResetDB
+	time.Sleep(5 * time.Second)
 	suite.Stop()
 }
 

--- a/util/cmdtest/cmds.go
+++ b/util/cmdtest/cmds.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -28,6 +29,7 @@ type IntegrationSuite struct {
 	suite.Suite
 	Ctx  context.Context
 	Stop func()
+	wg   sync.WaitGroup
 
 	logBuf *bytes.Buffer
 }
@@ -51,7 +53,7 @@ func (suite *IntegrationSuite) StoppableCtx() {
 		timeoutCancel()
 		cancel()
 		fmt.Println("stopping services")
-		time.Sleep(time.Second) // go needs a bit of time to kill process
+		suite.wg.Wait()
 	}
 }
 
@@ -68,10 +70,20 @@ func (suite *IntegrationSuite) StartDummy(args ...string) io.Reader {
 	cmd := exec.CommandContext(suite.Ctx, dummyBin, args...)
 	cmd.Stdout = outputWriter
 	cmd.Stderr = outputWriter
+
+	go func() {
+		// cmd.Wait() will not finish until stdout is closed
+		<-suite.Ctx.Done()
+		outputWriter.Close()
+	}()
+
 	err := cmd.Start()
 	suite.Require().NoError(err, "can't start analyzer")
 
+	suite.wg.Add(1)
 	go func() {
+		defer suite.wg.Done()
+
 		if err := cmd.Wait(); err != nil {
 			// don't print error if analyzer was killed by cancel
 			if suite.Ctx.Err() != context.Canceled {
@@ -142,6 +154,12 @@ func (suite *IntegrationSuite) startLookoutd(args ...string) (io.Reader, io.Writ
 	cmd.Stdout = outputWriter
 	cmd.Stderr = outputWriter
 
+	go func() {
+		// cmd.Wait() will not finish until stdout is closed
+		<-suite.Ctx.Done()
+		outputWriter.Close()
+	}()
+
 	fmt.Printf("starting lookoutd %s\n", strings.Join(args, " "))
 
 	w, err := cmd.StdinPipe()
@@ -150,7 +168,10 @@ func (suite *IntegrationSuite) startLookoutd(args ...string) (io.Reader, io.Writ
 	err = cmd.Start()
 	require.NoError(err, "can't start lookoutd")
 
+	suite.wg.Add(1)
 	go func() {
+		defer suite.wg.Done()
+
 		if err := cmd.Wait(); err != nil {
 			// don't print error if killed by cancel
 			if suite.Ctx.Err() != context.Canceled {

--- a/util/cmdtest/grep.go
+++ b/util/cmdtest/grep.go
@@ -13,36 +13,55 @@ import (
 // GrepTimeout defines timeout grep is waiting for substring
 var GrepTimeout = 30 * time.Second
 
-// GrepTrue reads from reader until finds substring with timeout or fails printing read lines
+const extraDebug = false
+
+// GrepTrue reads from reader until finds substring with timeout or fails,
+// printing read lines
 func (s *IntegrationSuite) GrepTrue(r io.Reader, substr string) {
-	found, buf := s.Grep(r, substr)
-	if !found {
-		fmt.Printf("'%s' is not found in output:\n", substr)
-		fmt.Println(buf.String())
-		fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
-		s.Stop()
-		s.Suite.T().FailNow()
-	}
+	s.GrepAll(r, []string{substr})
+}
+
+// GrepAll is like GrepTrue but for an array of strings. It waits util the last
+// line is found, then looks for all the lines in the read text
+func (s *IntegrationSuite) GrepAll(r io.Reader, strs []string) {
+	s.GrepAndNotAll(r, strs, nil)
 }
 
 // GrepAndNot reads from reader until finds substring with timeout and checks noSubstr was read
 // or fails printing read lines
 func (s *IntegrationSuite) GrepAndNot(r io.Reader, substr, noSubstr string) {
-	found, buf := s.Grep(r, substr)
-	if !found {
-		fmt.Printf("'%s' is not found in output:\n", substr)
-		fmt.Println(buf.String())
-		fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
-		s.Stop()
-		s.Suite.T().FailNow()
-		return
+	s.GrepAndNotAll(r, []string{substr}, []string{noSubstr})
+}
+
+// GrepAndNotAll is like GrepAndNot but for arrays of strings. It waits util
+// the last line is found, then looks for all the lines in the read text
+func (s *IntegrationSuite) GrepAndNotAll(r io.Reader, strs []string, noStrs []string) {
+	// If the stream from stdin is read sequentially with Grep(), there was
+	// an erratic behaviour where some lines where not processed.
+
+	// Wait until the last substr is found
+	_, buf := s.Grep(r, strs[len(strs)-1])
+	read := buf.String()
+
+	// Look for the previous messages in the lines read up to that last substr
+	for _, st := range strs {
+		if !strings.Contains(read, st) {
+			fmt.Printf("'%s' is not found in output:\n", st)
+			fmt.Println(read)
+			fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
+			s.Stop()
+			s.Suite.T().FailNow()
+		}
 	}
-	if strings.Contains(buf.String(), noSubstr) {
-		fmt.Printf("'%s' should not be in output:\n", noSubstr)
-		fmt.Println(buf.String())
-		fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
-		s.Stop()
-		s.Suite.T().FailNow()
+
+	for _, st := range noStrs {
+		if strings.Contains(read, st) {
+			fmt.Printf("'%s' should not be in output:\n", st)
+			fmt.Println(read)
+			fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
+			s.Stop()
+			s.Suite.T().FailNow()
+		}
 	}
 }
 
@@ -71,14 +90,18 @@ func (s *IntegrationSuite) Grep(r io.Reader, substr string) (bool, *bytes.Buffer
 	}()
 	select {
 	case <-time.After(GrepTimeout):
-		fmt.Printf(" >>>> Grep Timeout reached")
+		if extraDebug {
+			fmt.Printf(" >>>> Grep Timeout reached")
+		}
 
 		break
 	case found = <-foundch:
 	}
 
-	fmt.Printf("----------------\nGrep called for substr %q. Found: %v. Read:\n%s\n\n", substr, found, buf.String())
-	fmt.Printf("The complete command output so far:\n%s", s.logBuf.String())
+	if extraDebug {
+		fmt.Printf("----------------\nGrep called for substr %q. Found: %v. Read:\n%s\n\n", substr, found, buf.String())
+		fmt.Printf("The complete command output so far:\n%s", s.logBuf.String())
+	}
 
 	return found, buf
 }

--- a/util/cmdtest/grep.go
+++ b/util/cmdtest/grep.go
@@ -19,8 +19,9 @@ func (s *IntegrationSuite) GrepTrue(r io.Reader, substr string) {
 	if !found {
 		fmt.Printf("'%s' is not found in output:\n", substr)
 		fmt.Println(buf.String())
+		fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
 		s.Stop()
-		s.Suite.T().Fail()
+		s.Suite.T().FailNow()
 	}
 }
 
@@ -31,15 +32,17 @@ func (s *IntegrationSuite) GrepAndNot(r io.Reader, substr, noSubstr string) {
 	if !found {
 		fmt.Printf("'%s' is not found in output:\n", substr)
 		fmt.Println(buf.String())
+		fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
 		s.Stop()
-		s.Suite.T().Fail()
+		s.Suite.T().FailNow()
 		return
 	}
 	if strings.Contains(buf.String(), noSubstr) {
 		fmt.Printf("'%s' should not be in output:\n", noSubstr)
 		fmt.Println(buf.String())
+		fmt.Printf("\nThe complete command output:\n%s", s.logBuf.String())
 		s.Stop()
-		s.Suite.T().Fail()
+		s.Suite.T().FailNow()
 	}
 }
 


### PR DESCRIPTION
Fix #323

Integration tests have been failing erratically for a long time.
In this PR I've made the following changes:
- Make sure processes are killed before ending the tests
- Wait for the analyzer connections to be ready before sending any events
- Refactor the stdin grep. A lot of times two consecutive calls to `GrepTrue` ended up with the reading cursor somehow missing a line, and the tests failed waiting for that ghost line that. The `io` package actually says "clients should not assume they are safe for parallel execution."