### PR TITLE
Clean docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-ADD ./build/bin/lookoutd /bin/lookoutd
+COPY ./build/bin/lookoutd /bin/lookoutd
 
 ENTRYPOINT ["/bin/lookoutd"]
 CMD [ "serve" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates && \
+    apt-get install --no-install-recommends -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 ADD ./build/bin/lookoutd /bin/lookoutd


### PR DESCRIPTION
Hello,

This prevents extra packages from being installed, which helps reduce

the change we'll take an unknown dependency, such as `ca-certificates`. 

And, The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref:https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.
