### PR TITLE
Revert "Remove style analyzer while we deploy it in staging"

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -27,6 +27,9 @@ providers:
     installation_sync_interval: 5m
 
 analyzers:
+  - name: style-analyzer
+    addr: ipv4://lookout-style-analyzer:2000
+    feedback: https://github.com/src-d/style-analyzer/issues/new
   - name: gometalint-analyzer
     addr: ipv4://lookout-gometalint-analyzer:10303
     feedback: https://github.com/src-d/lookout-gometalint-analyzer/issues/new


### PR DESCRIPTION
Now that we've been able to deploy style analyzer, let's place this configuration back

Reverts src-d/lookout#340