### PR TITLE
Fix http cache with authorized requests

### DIFF
--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/src-d/lookout/util/ctxlog"
 
 	"github.com/google/go-github/github"
-	"github.com/gregjones/httpcache"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	log "gopkg.in/src-d/go-log.v1"
 )
@@ -252,10 +251,6 @@ func NewClient(
 		Base: t,
 	}
 
-	cachedT := httpcache.NewTransport(cache)
-	cachedT.MarkCachedResponses = true
-	cachedT.Transport = limitRT
-
 	interval := minInterval
 	if watchMinInterval != "" {
 		d, err := time.ParseDuration(watchMinInterval)
@@ -272,7 +267,7 @@ func NewClient(
 
 	return &Client{
 		Client: github.NewClient(&http.Client{
-			Transport: cachedT,
+			Transport: limitRT,
 			Timeout:   timeout,
 		}),
 		cache:            cache,

--- a/provider/github/installations.go
+++ b/provider/github/installations.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bradleyfalzon/ghinstallation"
-	"github.com/google/go-github/github"
 	"github.com/src-d/lookout"
 	"github.com/src-d/lookout/util/cache"
 	"github.com/src-d/lookout/util/ctxlog"
+
+	"github.com/bradleyfalzon/ghinstallation"
+	"github.com/google/go-github/github"
+	"github.com/gregjones/httpcache"
 	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
@@ -127,7 +129,10 @@ func (t *Installations) removeInstallation(id int64) {
 }
 
 func (t *Installations) createClient(installationID int64) (*Client, error) {
-	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport,
+	cachedT := httpcache.NewTransport(t.cache)
+	cachedT.MarkCachedResponses = true
+
+	itr, err := ghinstallation.NewKeyFromFile(cachedT,
 		t.appID, int(installationID), t.privateKey)
 	if err != nil {
 		return nil, err

--- a/provider/github/poster_test.go
+++ b/provider/github/poster_test.go
@@ -102,7 +102,7 @@ func (s *PosterTestSuite) SetupTest() {
 	githubURL, _ := url.Parse(s.server.URL + "/")
 
 	repoURLs := []string{"github.com/foo/bar"}
-	s.pool = newTestPool(s.Suite, repoURLs, githubURL, cache)
+	s.pool = newTestPool(s.Suite, repoURLs, githubURL, cache, false)
 }
 
 func (s *PosterTestSuite) TearDownTest() {

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -54,7 +54,7 @@ func NewClientPoolFromTokens(
 		cachedT := httpcache.NewTransport(cache)
 		cachedT.MarkCachedResponses = true
 
-		rt := &roundTripper{
+		rt := &basicAuthRoundTripper{
 			User:     conf.User,
 			Password: conf.Token,
 			Base:     cachedT,
@@ -85,13 +85,13 @@ func NewClientPoolFromTokens(
 	return pool, nil
 }
 
-type roundTripper struct {
+type basicAuthRoundTripper struct {
 	Base     http.RoundTripper
 	User     string
 	Password string
 }
 
-func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctxlog.Get(req.Context()).With(log.Fields{
 		"url":  req.URL.String(),
 		"user": t.User,
@@ -109,4 +109,4 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return rt.RoundTrip(req)
 }
 
-var _ http.RoundTripper = &roundTripper{}
+var _ http.RoundTripper = &basicAuthRoundTripper{}

--- a/provider/github/token_transport.go
+++ b/provider/github/token_transport.go
@@ -9,6 +9,7 @@ import (
 	"github.com/src-d/lookout/util/cache"
 	"github.com/src-d/lookout/util/ctxlog"
 
+	"github.com/gregjones/httpcache"
 	vcsurl "gopkg.in/sourcegraph/go-vcsurl.v1"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
@@ -50,9 +51,13 @@ func NewClientPoolFromTokens(
 	byClients := make(map[*Client][]*lookout.RepositoryInfo, len(byConfig))
 	byRepo := make(map[string]*Client, len(urlToConfig))
 	for conf, repos := range byConfig {
+		cachedT := httpcache.NewTransport(cache)
+		cachedT.MarkCachedResponses = true
+
 		rt := &roundTripper{
 			User:     conf.User,
 			Password: conf.Token,
+			Base:     cachedT,
 		}
 
 		// Auth must be: https://<token>@github.com/owner/repo.git


### PR DESCRIPTION
Fix #124.

The problem was that we were chaining `RoundTrippers` like this:
`httpcache` -> `limit` -> `github Auth`.
So the cache was getting requests that did not have any auth headers added yet, but when the responses got back from github, they did have those headers.
When comparing requests with the stored responses the headers did not match, and the cache was never used.

With this PR the `RoundTrippers` are now chained like this: `limit` -> `github Auth` -> `httpcache`.