### PR TITLE
Adds link to new flake8 analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This is a list of the available analyzers for lookout:
 | [gometalint](https://github.com/src-d/lookout-gometalint-analyzer) | Reports [gometalinter](https://github.com/alecthomas/gometalinter) results on pull requests | testing and demo |
 | [sonarcheck](https://github.com/src-d/lookout-sonarcheck-analyzer) | An analyzer that uses [bblfsh UAST](https://doc.bblf.sh/uast/uast-specification.html) and [sonar-checks](https://github.com/bblfsh/sonar-checks) to process pull requests | testing and demo |
 | [terraform](https://github.com/meyskens/lookout-terraform-analyzer) | An analyzer that checks if [Terraform](https://github.com/hashicorp/terraform/) files are correctly formatted | usable |
+| [flake8](https://github.com/src-d/lookout-flake8-analyzer) | Reports [flake8](http://flake8.pycqa.org/en/latest/) files are correctly formatted | testing and demo |
 
 
 # SDK for Analyzer Developers


### PR DESCRIPTION
Adds link to new [flake8 analyzer](https://github.com/src-d/lookout-flake8-analyzer) in the README.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>