### PR TITLE
Decouple rabbitmq and lookout

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ helm_deploy: &helm_deploy
   skip_tls_verify: true
   helm_repos: srcd-charts=https://src-d.github.io/charts/
   chart: srcd-charts/lookout
-  chart-version: 0.6.1
+  chart-version: 0.7.0
   release: lookout
   tiller_ns: lookout
   namespace: lookout

--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -10,6 +10,10 @@ databases:
     serviceAccountSecret: cloudsql-proxy-credentials
     connectionDetailsSecret: lookout-postgres-connection-details
 
+queues:
+  rabbitmq:
+    connectionString: amqp://lookout-rabbitmq-ha:5672
+
 nodeSelector:
  lookout:
    srcd.host/app: lookout
@@ -39,11 +43,3 @@ analyzers:
   - name: terraform-analyzer
     addr: ipv4://lookout-terraform-analyzer:10303
     feedback: https://github.com/src-d/lookout-terraform-analyzer/issues/new
-
-rabbitmq-ha:
-  replicaCount: 1
-  rbac:
-    create: false
-  persistentVolume:
-    enabled: true
-    size: 10Gi


### PR DESCRIPTION
They are not deployed using the same chart

Do not merge. This needs some deployment tasks done elsewhere.

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>