### PR TITLE
Add log fields metadata to gRPC calls

### DIFF
--- a/cmd/server-test/dummy_analyzer_test.go
+++ b/cmd/server-test/dummy_analyzer_test.go
@@ -43,6 +43,17 @@ func (suite *DummyIntegrationSuite) TestSuccessReview() {
 	})
 }
 
+func (suite *DummyIntegrationSuite) TestGRPCLogs() {
+	// Check that 'event-id' log field is sent from lookoutd to the dummy analyzer,
+	// and then received back when receiving a grpc call from the analyzer.
+	suite.sendEvent(successJSON)
+	suite.GrepAll(suite.r, []string{
+		`processing pull request`,
+		`msg="gRPC streaming server call started" analyzer=Dummy app=lookoutd event-id=16ee0f607886b841c7633ab4cea5334cbc2022a1 event-type="*pb.ReviewEvent" grpc.method=GetChanges`,
+		`status=success`,
+	})
+}
+
 func (suite *DummyIntegrationSuite) TestReviewDontPostSameComment() {
 	fixture := fixtures.GetByName("incremental-pr")
 

--- a/cmd/server-test/multi_analyzer_test.go
+++ b/cmd/server-test/multi_analyzer_test.go
@@ -40,7 +40,7 @@ func (suite *MultiDummyIntegrationSuite) TestSuccessReview() {
 
 	str := suite.GrepAll(suite.r, []string{
 		"processing pull request",
-		`msg="posting analysis" app=lookoutd comments=4`,
+		`msg="posting analysis" analyzer=Dummy1 app=lookoutd comments=4`,
 		`status=success`,
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -299,7 +299,7 @@ func (s *Server) concurrentRequest(ctx context.Context, conf map[string]lookout.
 			var result *lookout.AnalyzerComments
 			defer func() { commentsCh <- result }()
 
-			aLogger := ctxlog.Get(ctx).With(log.Fields{
+			ctx, aLogger := ctxlog.WithLogFields(ctx, log.Fields{
 				"analyzer": name,
 			})
 

--- a/util/grpchelper/logfields.go
+++ b/util/grpchelper/logfields.go
@@ -1,0 +1,86 @@
+package grpchelper
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/src-d/lookout/util/ctxlog"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	log "gopkg.in/src-d/go-log.v1"
+)
+
+const logFieldsKey = "log-fields"
+
+// CtxlogUnaryClientInterceptor is a unary client interceptor that adds the
+// ctxlog log.Fields to the grpc metadata, with the key 'logFieldsKey'.
+func CtxlogUnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ctx = setLogFieldsMetadata(ctx)
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+// CtxlogStreamClientInterceptor is a streaming client interceptor that adds the
+// ctxlog log.Fields to the grpc metadata, with the key 'logFieldsKey'.
+func CtxlogStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ctx = setLogFieldsMetadata(ctx)
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+// setLogFieldsMetadata returns a new context with the ctxlog log.Fields stored
+// into the grpc metadata, with the key 'logFieldsKey'.
+func setLogFieldsMetadata(ctx context.Context) context.Context {
+	f := ctxlog.Fields(ctx)
+
+	// Delete the fields that should not cross to the gRPC server logs
+	delete(f, "app")
+
+	bytes, err := json.Marshal(f)
+	if err != nil {
+		ctxlog.Get(ctx).Errorf(err, "log.Fields could not be marshaled to JSON")
+		return ctx
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, logFieldsKey, string(bytes))
+}
+
+// CtxlogUnaryServerInterceptor is a unary server interceptor that adds
+// to the context a ctxlog configured with the log Fields found in the request
+// metadata.
+func CtxlogUnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	ctx = setContextLogger(ctx)
+	return handler(ctx, req)
+}
+
+// CtxlogStreamServerInterceptor is a streaming server interceptor that
+// adds to the context a ctxlog configured with the log Fields found in the
+// request metadata.
+func CtxlogStreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	wrapped := grpc_middleware.WrapServerStream(stream)
+	wrapped.WrappedContext = setContextLogger(stream.Context())
+
+	return handler(srv, wrapped)
+}
+
+// setContextLogger returns a new context containing a ctxlog configured with
+// the log Fields found in the given ctx metadata.
+func setContextLogger(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok || len(md[logFieldsKey]) == 0 {
+		return ctx
+	}
+
+	var f log.Fields
+	err := json.Unmarshal([]byte(md[logFieldsKey][0]), &f)
+	if err != nil {
+		ctxlog.Get(ctx).Errorf(err, "log.Fields could not be unmarshaled from JSON")
+		return ctx
+	}
+
+	// Delete the fields that we don't want overwritten by a gRPC client
+	delete(f, "app")
+
+	newCtx, _ := ctxlog.WithLogFields(ctx, f)
+	return newCtx
+}

--- a/util/grpchelper/logger.go
+++ b/util/grpchelper/logger.go
@@ -5,7 +5,8 @@ import (
 	"path"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/src-d/lookout/util/ctxlog"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"google.golang.org/grpc"
 	log "gopkg.in/src-d/go-log.v1"
@@ -19,93 +20,98 @@ func getLogFn(l log.Logger, asDebug bool) func(msg string, args ...interface{}) 
 	return l.Infof
 }
 
-// UnaryServerInterceptor returns a new unary server interceptors that logs request/response.
-func UnaryServerInterceptor(l log.Logger, asDebug bool) grpc.UnaryServerInterceptor {
+// LogUnaryServerInterceptor returns a new unary server interceptor that logs
+// request/response.
+func LogUnaryServerInterceptor(asDebug bool) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		startTime := time.Now()
 
-		l := newServerRequestLogger(l, info.FullMethod)
-		getLogFn(l, asDebug)("unary server call started")
+		l := newServerRequestLogger(ctx, info.FullMethod)
+		getLogFn(l, asDebug)("gRPC unary server call started")
 
 		resp, err := handler(ctx, req)
 
-		getLogFn(newResponseLogger(l, startTime, err), asDebug)("unary server call finished")
+		getLogFn(newResponseLogger(l, startTime, err), asDebug)("gRPC unary server call finished")
 
 		return resp, err
 	}
 }
 
-// StreamServerInterceptor returns a new streaming server interceptor that logs request/response.
-func StreamServerInterceptor(l log.Logger, asDebug bool) grpc.StreamServerInterceptor {
+// LogStreamServerInterceptor returns a new streaming server interceptor that
+// logs request/response.
+func LogStreamServerInterceptor(asDebug bool) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		startTime := time.Now()
 
-		l := newServerRequestLogger(l, info.FullMethod)
-		getLogFn(l, asDebug)("streaming server call started")
+		l := newServerRequestLogger(stream.Context(), info.FullMethod)
+		getLogFn(l, asDebug)("gRPC streaming server call started")
 
-		wrapped := grpc_middleware.WrapServerStream(stream)
-		err := handler(srv, wrapped)
+		err := handler(srv, stream)
 
-		getLogFn(newResponseLogger(l, startTime, err), asDebug)("streaming server call finished")
+		getLogFn(newResponseLogger(l, startTime, err), asDebug)("gRPC streaming server call finished")
 
 		return err
 	}
 }
 
-// UnaryClientInterceptor returns a new unary client interceptor that logs the execution of external gRPC calls.
-func UnaryClientInterceptor(l log.Logger, asDebug bool) grpc.UnaryClientInterceptor {
+// LogUnaryClientInterceptor returns a new unary client interceptor that logs
+// the execution of external gRPC calls.
+func LogUnaryClientInterceptor(asDebug bool) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		startTime := time.Now()
 
-		l := newClientRequestLogger(l, method)
-		getLogFn(l, asDebug)("unary client call started")
+		l := newClientRequestLogger(ctx, method)
+		getLogFn(l, asDebug)("gRPC unary client call started")
 
 		err := invoker(ctx, method, req, reply, cc, opts...)
 
-		getLogFn(newResponseLogger(l, startTime, err), asDebug)("streaming client call finished")
+		getLogFn(newResponseLogger(l, startTime, err), asDebug)("gRPC unary client call finished")
 
 		return err
 	}
 }
 
-// StreamClientInterceptor returns a new striming client interceptor that logs the execution of external gRPC calls.
-func StreamClientInterceptor(l log.Logger, asDebug bool) grpc.StreamClientInterceptor {
+// LogStreamClientInterceptor returns a new streaming client interceptor that
+// logs the execution of external gRPC calls.
+func LogStreamClientInterceptor(asDebug bool) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		startTime := time.Now()
 
-		l := newClientRequestLogger(l, method)
-		getLogFn(l, asDebug)("streaming client call started")
+		l := newClientRequestLogger(ctx, method)
+		getLogFn(l, asDebug)("gRPC streaming client call started")
 
 		clientStream, err := streamer(ctx, desc, cc, method, opts...)
 
-		getLogFn(newResponseLogger(l, startTime, err), asDebug)("streaming client call finished")
+		getLogFn(newResponseLogger(l, startTime, err), asDebug)("gRPC streaming client call finished")
 
 		return clientStream, err
 	}
 }
 
-func newServerRequestLogger(l log.Logger, fullMethod string) log.Logger {
+func newServerRequestLogger(ctx context.Context, fullMethod string) log.Logger {
 	service := path.Dir(fullMethod)[1:]
 	method := path.Base(fullMethod)
 
-	return l.With(log.Fields{
+	_, logger := ctxlog.WithLogFields(ctx, log.Fields{
 		"system":       "grpc",
 		"span.kind":    "server",
 		"grpc.service": service,
 		"grpc.method":  method,
 	})
+	return logger
 }
 
-func newClientRequestLogger(l log.Logger, fullMethod string) log.Logger {
+func newClientRequestLogger(ctx context.Context, fullMethod string) log.Logger {
 	service := path.Dir(fullMethod)[1:]
 	method := path.Base(fullMethod)
 
-	return l.With(log.Fields{
+	_, logger := ctxlog.WithLogFields(ctx, log.Fields{
 		"system":       "grpc",
 		"span.kind":    "client",
 		"grpc.service": service,
 		"grpc.method":  method,
 	})
+	return logger
 }
 
 func newResponseLogger(l log.Logger, startTime time.Time, err error) log.Logger {


### PR DESCRIPTION
WIP because it needs support from go-log, https://github.com/src-d/go-log/pull/9. But I'd like to get feedback.

Fix #248.

The changes in this PR depend on fixing #357 to be really useful. But the issues are independent, the other bug can be fixed after this one is merged. In the examples below you can see the analyzer and event-id fields.

Changes in this PR include:

Improvements to already existing interceptors. Now they use a log from context, instead of the default one.
Before
```
[2018-11-19T11:09:35.061228511Z]  INFO unary client call started app=lookoutd grpc.method=NotifyReviewEvent grpc.service=pb.Analyzer span.kind=client system=grpc
```
After:
```
[2018-11-19T11:08:17.043544201Z]  INFO gRPC unary client call started analyzer=Dummy app=lookoutd event-id=47428977cec7253cc30466a12eee386de46f7306 event-type=*pb.ReviewEvent grpc.method=NotifyReviewEvent grpc.service=pb.Analyzer head=refs/pull/1/head provider=github repo=https://github.com/src-d/lookout-test-fixtures.git span.kind=client system=grpc
```

.
New interceptors to pass log fields in the gRPC metadata, encoded as JSON. Using these interceptors the logs fields go from `lookoutd` -> `analyzer` as client/server, but also from `analyzer` -> `lookoutd`.
Before:
```
[2018-11-19T11:23:46.423025958Z]  INFO gRPC streaming server call started app=lookoutd grpc.method=GetChanges grpc.service=pb.Data span.kind=server system=grpc
[2018-11-19T11:23:46.423263865Z]  INFO validating refs: [internal_repository_url:"https://github.com/src-d/lookout-test-fixtures.git" reference_name:"refs/heads/master" hash:"6a92946068897d0a6f6ffa6457f889163dcc51b5"  internal_repository_url:"https://github.com/src-d/lookout-test-fixtures.git" reference_name:"refs/pull/3/head" hash:"6221d2fe0bc2148debfa8d3c8c92b8c15451920d" ], validateRefName: true app=lookoutd
[2018-11-19T11:23:46.423559138Z]  INFO fetching references for repository https://github.com/src-d/lookout-test-fixtures.git: [refs/heads/master:refs/heads/master refs/pull/3/head:refs/pull/3/head] app=lookoutd
[2018-11-19T11:23:46.822346422Z]  INFO gRPC streaming server call finished app=lookoutd duration=399.322434ms grpc.code=OK grpc.method=GetChanges grpc.service=pb.Data grpc.start_time=2018-11-19T11:23:46Z span.kind=server system=grpc
```

After:
```
[2018-11-19T11:21:38.402117594Z]  INFO gRPC streaming server call started analyzer=Dummy app=lookoutd event-id=47428977cec7253cc30466a12eee386de46f7306 event-type=map[] grpc.method=GetChanges grpc.service=pb.Data head=refs/pull/1/head provider=github repo=https://github.com/src-d/lookout-test-fixtures.git span.kind=server system=grpc
[2018-11-19T11:21:38.402355891Z]  INFO validating refs: [internal_repository_url:"https://github.com/src-d/lookout-test-fixtures.git" reference_name:"refs/heads/i197-base" hash:"fa8a63d8ed4ceee82f40273090c28e31576dafda"  internal_repository_url:"https://github.com/src-d/lookout-test-fixtures.git" reference_name:"refs/pull/1/head" hash:"5fe468b62112e69bae390051e990271f7b1cc294" ], validateRefName: true analyzer=Dummy app=lookoutd event-id=47428977cec7253cc30466a12eee386de46f7306 event-type=map[] head=refs/pull/1/head provider=github repo=https://github.com/src-d/lookout-test-fixtures.git
[2018-11-19T11:21:38.402707005Z]  INFO fetching references for repository https://github.com/src-d/lookout-test-fixtures.git: [refs/heads/i197-base:refs/heads/i197-base refs/pull/1/head:refs/pull/1/head] analyzer=Dummy app=lookoutd event-id=47428977cec7253cc30466a12eee386de46f7306 event-type=map[] head=refs/pull/1/head provider=github repo=https://github.com/src-d/lookout-test-fixtures.git
[2018-11-19T11:21:39.024092952Z]  INFO gRPC streaming server call finished analyzer=Dummy app=lookoutd duration=621.987351ms event-id=47428977cec7253cc30466a12eee386de46f7306 event-type=map[] grpc.code=OK grpc.method=GetChanges grpc.service=pb.Data grpc.start_time=2018-11-19T11:21:38Z head=refs/pull/1/head provider=github repo=https://github.com/src-d/lookout-test-fixtures.git span.kind=server system=grpc
```

If an analyzer does not use the interceptors the log fields are not passed around, but it will not cause any problems. Since the metadata is JSON, it should be easy to add this functionality to the python SDK.