### PR TITLE
Single exit point and graceful shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,12 @@ bindata:
 
 
 GOTEST_INTEGRATION_TAGS_LIST = integration bblfsh
+GOTEST_INTEGRATION_TAGS = $(GOTEST_INTEGRATION_TAGS_LIST)
 
 # disable bblfsh on tests on travis mac os
 ifeq ($(TRAVIS),true)
 ifeq ($(OS),Darwin)
 GOTEST_INTEGRATION_TAGS = $(filter-out bblfsh,$(GOTEST_INTEGRATION_TAGS_LIST))
-else
-GOTEST_INTEGRATION_TAGS = $(GOTEST_INTEGRATION_TAGS_LIST)
 endif
 endif
 

--- a/cmd/lookout-sdk/event.go
+++ b/cmd/lookout-sdk/event.go
@@ -127,7 +127,10 @@ func (c *EventCommand) makeDataServerHandler() (*lookout.DataServerHandler, erro
 	return srv, nil
 }
 
-func (c *EventCommand) initDataServer(srv *lookout.DataServerHandler) (func() error, func()) {
+type startFunc func() error
+type stopFunc func()
+
+func (c *EventCommand) initDataServer(srv *lookout.DataServerHandler) (startFunc, stopFunc) {
 	var grpcSrv *grpc.Server
 
 	start := func() error {

--- a/cmd/lookout-sdk/event.go
+++ b/cmd/lookout-sdk/event.go
@@ -137,7 +137,7 @@ func (c *EventCommand) initDataServer(srv *lookout.DataServerHandler) (func() er
 			return fmt.Errorf("Can't resolve bblfsh address '%s': %s", c.Bblfshd, err)
 		}
 
-		grpcSrv, err := grpchelper.NewBblfshProxyServer(bblfshGrpcAddr)
+		grpcSrv, err = grpchelper.NewBblfshProxyServer(bblfshGrpcAddr)
 		if err != nil {
 			return fmt.Errorf("Can't start bblfsh proxy server: %s", err)
 		}

--- a/cmd/lookout-sdk/event.go
+++ b/cmd/lookout-sdk/event.go
@@ -127,28 +127,40 @@ func (c *EventCommand) makeDataServerHandler() (*lookout.DataServerHandler, erro
 	return srv, nil
 }
 
-func (c *EventCommand) bindDataServer(srv *lookout.DataServerHandler, serveResult chan error) (*grpc.Server, error) {
-	log.Infof("starting a DataServer at %s", c.DataServer)
-	bblfshGrpcAddr, err := grpchelper.ToGoGrpcAddress(c.Bblfshd)
-	if err != nil {
-		return nil, fmt.Errorf("Can't resolve bblfsh address '%s': %s", c.Bblfshd, err)
+func (c *EventCommand) initDataServer(srv *lookout.DataServerHandler) (func() error, func()) {
+	var grpcSrv *grpc.Server
+
+	start := func() error {
+		log.Infof("starting a DataServer at %s", c.DataServer)
+		bblfshGrpcAddr, err := grpchelper.ToGoGrpcAddress(c.Bblfshd)
+		if err != nil {
+			return fmt.Errorf("Can't resolve bblfsh address '%s': %s", c.Bblfshd, err)
+		}
+
+		grpcSrv, err := grpchelper.NewBblfshProxyServer(bblfshGrpcAddr)
+		if err != nil {
+			return fmt.Errorf("Can't start bblfsh proxy server: %s", err)
+		}
+
+		lookout.RegisterDataServer(grpcSrv, srv)
+
+		lis, err := grpchelper.Listen(c.DataServer)
+		if err != nil {
+			return fmt.Errorf("Can't start data server at '%s': %s", c.DataServer, err)
+		}
+
+		return grpcSrv.Serve(lis)
 	}
 
-	grpcSrv, err := grpchelper.NewBblfshProxyServer(bblfshGrpcAddr)
-	if err != nil {
-		return nil, fmt.Errorf("Can't start bblfsh proxy server: %s", err)
+	stop := func() {
+		if grpcSrv == nil {
+			return
+		}
+
+		grpcSrv.GracefulStop()
 	}
 
-	lookout.RegisterDataServer(grpcSrv, srv)
-
-	lis, err := grpchelper.Listen(c.DataServer)
-	if err != nil {
-		return nil, fmt.Errorf("Can't start data server at '%s': %s", c.DataServer, err)
-	}
-
-	go func() { serveResult <- grpcSrv.Serve(lis) }()
-
-	return grpcSrv, nil
+	return start, stop
 }
 
 func (c *EventCommand) analyzerClient() (lookout.AnalyzerClient, error) {

--- a/cmd/lookoutd/work.go
+++ b/cmd/lookoutd/work.go
@@ -95,6 +95,8 @@ func (c *WorkCommand) Execute(args []string) error {
 
 	c.probeReadiness = true
 
+	ctxlog.Get(ctx).Infof("Worker started")
+
 	err = <-stopCh
 
 	// stop servers gracefully

--- a/util/cmdtest/cmds.go
+++ b/util/cmdtest/cmds.go
@@ -113,7 +113,7 @@ func (suite *IntegrationSuite) StartLookoutd(configFile string) (io.Reader, io.W
 		suite.GrepTrue(watcherR, "Starting watcher")
 
 		// make sure worker started correctly
-		suite.GrepTrue(workerR, "connection with the DB established")
+		suite.GrepTrue(workerR, "Worker started")
 
 		// Write json commands to watcher, write processed output from worker
 		return workerR, watcherW


### PR DESCRIPTION
Fix: #362

Single exit point allows kind of proper graceful shutdown.
We don't crush ongoing analyzer requests at least.
But internally we don't have the ability to shut down everything 100% correctly (for example cloning of repository). Even now I send a signal to stop everything but there is no way to acknowledge cancellation:

```go
package context

// A CancelFunc tells an operation to abandon its work.
// A CancelFunc does not wait for the work to stop.
// After the first call, subsequent calls to a CancelFunc do nothing.
type CancelFunc func()
```

which means we may kill the process before cancelation finished. More info from [Dave Cheney](https://dave.cheney.net/2017/08/20/context-isnt-for-cancellation)

Log messages changed because the blocked function can return nil as an error. (for example check `runEventEnqueuer` implementation)

Sdk changed just to be consistent with the server.