### PR TITLE
Don't add footer to empty comment. Fix #371

### DIFF
--- a/provider/github/review.go
+++ b/provider/github/review.go
@@ -208,7 +208,7 @@ func splitReviewRequest(review *github.PullRequestReviewRequest, n int) []*githu
 
 // addFootnote adds footnote link to text of a comment
 func addFootnote(text, tmpl, url string) string {
-	if tmpl == "" || url == "" {
+	if text == "" || tmpl == "" || url == "" {
 		return text
 	}
 


### PR DESCRIPTION
Bug was introduced in #356
Review body should also contain footer if it exists.
But addFootnote function didn't have check for empty text which caused
reviews with footers only.

Signed-off-by: Maxim Sukharev <max@smacker.ru>