### PR TITLE
Add log fields to queue jobs

### DIFF
--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -250,8 +250,7 @@ func (w *Watcher) handlePrs(ctx context.Context,
 
 	for _, e := range prs {
 		ctx, _ := ctxlog.WithLogFields(ctx, log.Fields{
-			"pr-id":     e.GetID(),
-			"pr-number": e.GetNumber(),
+			"github.pr": e.GetNumber(),
 		})
 		event := castPullRequest(ctx, r, e)
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -55,7 +55,7 @@ func nextEOF(t *testing.T, iter queue.JobIter) {
 }
 
 func TestQueueJobCreation(t *testing.T) {
-	qJob, err := NewQueueJob(&mockEventA)
+	qJob, err := NewQueueJob(context.TODO(), &mockEventA)
 	require.NoError(t, err)
 	require.NotNil(t, qJob)
 

--- a/util/ctxlog/context.go
+++ b/util/ctxlog/context.go
@@ -22,9 +22,22 @@ func Get(ctx context.Context) log.Logger {
 	return log.New(fields)
 }
 
+// Fields returns the context log fields. It can be nil
+func Fields(ctx context.Context) log.Fields {
+	if v := ctx.Value(logFieldsKey); v != nil {
+		return v.(log.Fields)
+	}
+
+	return nil
+}
+
 // WithLogFields returns a context with new logger Fields added to the current
 // ones, and a logger
 func WithLogFields(ctx context.Context, fields log.Fields) (context.Context, log.Logger) {
+	if fields == nil {
+		return ctx, Get(ctx)
+	}
+
 	var newFields log.Fields
 
 	if v := ctx.Value(logFieldsKey); v != nil {


### PR DESCRIPTION
Fix #357.

WIP because it depends on https://github.com/src-d/go-log/pull/9.

I checked that if an old queue job without the field in this PR is dequeued and deserialized, it works without a problem.
I changed the fields added by the github provider because `pr-number` does not really help to identify, and adds noise. I also added a `github.` prefix to help organize log fields a bit better, the same way we have `grpc.start_time`, `grpc.code`.