### PR TITLE
Remove --verbose option

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -49,7 +49,6 @@ Both `lookout-sdk push` and `lookout-sdk review` can be configured with environm
 | `LOG_FORMAT`| `--log-format=` | log format (`text` or `json`), defaults to `text` on a terminal and `json` otherwise | |
 | `LOG_FIELDS` | `--log-fields=` | default fields for the logger, specified in json | |
 | `LOG_FORCE_FORMAT` | `--log-force-format` | ignore if it is running on a terminal or not | |
-| | `-v`, `--verbose` | enable verbose logging | |
 | `LOOKOUT_DATA_SERVER`  | `--data-server=` | gRPC URL to bind the data server to | `ipv4://localhost:10301` |
 | `LOOKOUT_BBLFSHD` | `--bblfshd=` | gRPC URL of the Bblfshd server | `ipv4://localhost:9432` |
 | `GIT_DIR` | `--git-dir=` | path to the Git directory to analyze | `.` _(current dir)_ |

--- a/util/cli/log.go
+++ b/util/cli/log.go
@@ -13,17 +13,12 @@ type LogOptions struct {
 	LogFormat      string `long:"log-format" env:"LOG_FORMAT" description:"log format (text or json), defaults to text on a terminal and json otherwise"`
 	LogFields      string `long:"log-fields" env:"LOG_FIELDS" description:"default fields for the logger, specified in json"`
 	LogForceFormat bool   `long:"log-force-format" env:"LOG_FORCE_FORMAT" description:"ignore if it is running on a terminal or not"`
-	Verbose        bool   `long:"verbose" short:"v" description:"enable verbose logging"`
 }
 
 var _ initializer = &LogOptions{}
 
 // Init initializes the default logger factory.
 func (c *LogOptions) init(app *App) {
-	if c.Verbose {
-		c.LogLevel = "debug"
-	}
-
 	if c.LogFields == "" {
 		bytes, err := json.Marshal(log.Fields{"app": app.Name})
 		if err != nil {


### PR DESCRIPTION
Fix #374 

The `--verbose` option just sets the log level to `debug`. And we already have another option for that.
It collides if you try to use both, and causes confusion.