### PR TITLE
Remove timeouts in lookout-sdk

### DIFF
--- a/cmd/lookoutd/common.go
+++ b/cmd/lookoutd/common.go
@@ -109,6 +109,15 @@ func (c *lookoutdCommand) initConfig() (Config, error) {
 		return conf, fmt.Errorf("Can't open configuration file: %s", err)
 	}
 
+	// Set default timeouts
+	conf.Timeout = TimeoutConfig{
+		AnalyzerReview: 10 * time.Minute,
+		AnalyzerPush:   60 * time.Minute,
+		GithubRequest:  time.Minute,
+		GitFetch:       20 * time.Minute,
+		BblfshParse:    2 * time.Minute,
+	}
+
 	if err := yaml.Unmarshal([]byte(configData), &conf); err != nil {
 		return conf, fmt.Errorf("Can't parse configuration file: %s", err)
 	}

--- a/provider/github/client.go
+++ b/provider/github/client.go
@@ -240,7 +240,8 @@ type Client struct {
 	gitAuth          gitAuthFn
 }
 
-// NewClient creates new Client
+// NewClient creates new Client.
+// A timeout of zero means no timeout.
 func NewClient(
 	t http.RoundTripper,
 	cache *cache.ValidableCache,
@@ -264,10 +265,6 @@ func NewClient(
 		} else {
 			interval = d
 		}
-	}
-
-	if timeout == 0 {
-		timeout = 30 * time.Second
 	}
 
 	return &Client{


### PR DESCRIPTION
Fix #376.

This PR does:
- Moves the timeout defaults to `lookoutd` config initialization. This allows to:
  - Have no timeouts for `lookout-sdk`
  - See the values that apply in the initial config logs (in master the default timeouts are shown as `0` in the config logs)
- Increase the default timeouts. There is not much to gain from lower timeouts, and make the ML team analyzer fail.

The `lookout-sdk` is a tool that runs once, for manual testing, and you can cancel with a `ctrl+c`. It makes sense to remove any timeouts.