### PR TITLE
Fix timeout yml keys in conf file

### DIFF
--- a/cmd/lookoutd/common.go
+++ b/cmd/lookoutd/common.go
@@ -87,11 +87,11 @@ type RepoConfig struct {
 
 // TimeoutConfig holds configuration for timeouts
 type TimeoutConfig struct {
-	AnalyzerReview time.Duration
-	AnalyzerPush   time.Duration
-	GithubRequest  time.Duration
-	GitFetch       time.Duration
-	BblfshParse    time.Duration
+	AnalyzerReview time.Duration `yaml:"analyzer_review"`
+	AnalyzerPush   time.Duration `yaml:"analyzer_push"`
+	GithubRequest  time.Duration `yaml:"github_request"`
+	GitFetch       time.Duration `yaml:"git_fetch"`
+	BblfshParse    time.Duration `yaml:"bblfsh_parse"`
 }
 
 func (c *lookoutdCommand) initConfig() (Config, error) {

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -18,3 +18,16 @@ repositories:
       # user:
       # token:
       # minInterval: 1m
+
+# These are the default timeout values. A value of 0 means no timeout
+timeout:
+  # Timeout for an analyzer response to a NotifyReviewEvent
+  analyzer_review: 10m
+  # Timeout for an analyzer response to a NotifyPushEvent
+  analyzer_push: 60m
+  # Timeout http requests to the GitHub API
+  github_request: 1m
+  # Timeout for Git fetch actions
+  git_fetch: 20m
+  # Timeout for parse requests to Bblfsh
+  bblfsh_parse: 2m

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,15 +148,21 @@ The `settings` for each analyzer in the `.lookout.yml` config file will be merge
 
 ### Advanced fine-tuning
 
-Configuration file also provides possibility to change default timeouts.
+The configuration file also provides the possibility to change default timeouts.
 
-Below is the list of different timeouts with default values:
+Below is the list of different timeouts with their default values:
 
 ```yaml
+# These are the default timeout values. A value of 0 means no timeout
 timeout:
-  analyzer_review: 5m
-  analyzer_push: 30m
-  github_request: 30s
-  git_fetch: 10m
-  bblfsh_parse: 60s
+  # Timeout for an analyzer response to a NotifyReviewEvent
+  analyzer_review: 10m
+  # Timeout for an analyzer response to a NotifyPushEvent
+  analyzer_push: 60m
+  # Timeout http requests to the GitHub API
+  github_request: 1m
+  # Timeout for Git fetch actions
+  git_fetch: 20m
+  # Timeout for parse requests to Bblfsh
+  bblfsh_parse: 2m
 ```


### PR DESCRIPTION
Fix #381.

The keys were `analyzerreview` instead of the ones in the docs, `analyzer_review`. I also added the timeouts to the template conf file.

The default values are the ones from #380.