### PR TITLE
Update kallax model with latest bin

### DIFF
--- a/store/models/kallax.go
+++ b/store/models/kallax.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/src-d/go-kallax.v1"
+	kallax "gopkg.in/src-d/go-kallax.v1"
 	"gopkg.in/src-d/go-kallax.v1/types"
 	"gopkg.in/src-d/lookout-sdk.v0/pb"
 )


### PR DESCRIPTION
Builds are failing because the latest `kallax` bin changes the generated code import.
See for example https://travis-ci.org/src-d/lookout/jobs/463244318#L945