### PR TITLE
fix: Change log level to debug for installation sync message

### DIFF
--- a/provider/github/installations.go
+++ b/provider/github/installations.go
@@ -72,7 +72,7 @@ func NewInstallations(
 
 // Sync update state from github
 func (t *Installations) Sync() error {
-	log.Infof("syncing installations with github")
+	log.Debugf("syncing installations with github")
 
 	var installations []*github.Installation
 	opts := &github.ListOptions{


### PR DESCRIPTION
On staging we log it every 5 second. It doesn't make any sense.

Signed-off-by: Maxim Sukharev <max@smacker.ru>