### PR TITLE
Skip macOS tests on PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
         - make test-json
         - LOOKOUT_TEST_QUEUE=true make test-json
     - name: 'Lookoutd Integration Tests macOS'
+      if: NOT type = pull_request
       script:
         - make ci-integration-dependencies
         - psql -c 'create database lookout;' -U postgres


### PR DESCRIPTION
We are already skipping "SDK Integration Tests macOS" on PR to speed up build times. With this PR we also skip "Lookoutd Integration Tests macOS".

A [recent build](https://travis-ci.org/src-d/lookout/builds/464865586) took 15min for macOS tests, when the linux ones were done in 3min.