### PR TITLE
fix: Use string instead of reflect.Type as log field

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -57,7 +57,7 @@ func NewServer(
 // HandleEvent processes the event calling the analyzers, and posting the results
 func (s *Server) HandleEvent(ctx context.Context, e lookout.Event) error {
 	ctx, logger := ctxlog.WithLogFields(ctx, log.Fields{
-		"event-type": reflect.TypeOf(e),
+		"event-type": reflect.TypeOf(e).String(),
 		"event-id":   e.ID().String(),
 		"repo":       e.Revision().Head.InternalRepositoryURL,
 		"head":       e.Revision().Head.ReferenceName,


### PR DESCRIPTION
With JSON formatter reflect.Type is formatted as "{}"

Example from staging logs:
```
{
    "app":"lookoutd",
    "event-id":"6052c4a4bda3c9807c9ec80c0955f85ee709a359",
    "event-type":{},
    "head":"refs/pull/395/head",
    "level":"info",
    "msg":"processing pull request",
    "provider":"github",
    "repo":"https://github.com/src-d/lookout.git",
    "source":"server/server.go:116",
    "time":"2018-12-07T10:57:47.489675762Z"
}
```

Signed-off-by: Maxim Sukharev <max@smacker.ru>