### PR TITLE
Set defaults for GITHUB_USER and GITHUB_TOKEN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - postgres
       - dummy
     environment:
-      GITHUB_USER: ${GITHUB_USER}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      GITHUB_USER: ${GITHUB_USER:-}
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     ports:
       - "10301:10301"
     entrypoint: ["/bin/sh"]


### PR DESCRIPTION
fix #384

Use [docker-compose defaults](https://docs.docker.com/compose/compose-file/#variable-substitution) for:
```shell
GITHUB_USER
GITHUB_TOKEN
```