### PR TITLE
Set a fixtures repo in config-template

### DIFF
--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -13,7 +13,7 @@ providers:
     # watch_min_interval: 2s
 
 repositories:
-  - url: github.com/src-d/lookout
+  - url: github.com/src-d/lookout-test-fixtures
     client:
       # user:
       # token:


### PR DESCRIPTION
superseded by https://github.com/src-d/lookout/pull/410

When a newcomer creates the `config.yml` with a copy/paste from `config.yml.tpl` and then runs `lookout`, it will spam **lookout** main repo.

If this PR is merged, the watched repo will be `github.com/src-d/lookout-test-fixtures` instead of the main one.

### alternative
Set a placeholder, with a missing repo, so the user will be forced to change it.
- **cons:**
  - it will be needed an extra step to try **lookout**,
  - The user might not have a testing repo in case he don't want to spam their own repos for trying lookout.
- **pros:**
  - the user is forced to think before starting running commands :wink: 

Adopting the alternative without solving #385 (**_If a repo added in config.yml does not exist, CLI is flooded with 404 requests_**) could lead into a bad UX.