### PR TITLE
Change default repo in config-template. Setting a placeholder

### DIFF
--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -13,7 +13,7 @@ providers:
     # watch_min_interval: 2s
 
 repositories:
-  - url: github.com/src-d/lookout
+  - url: github.com/_USER_/_REPO_TO_WATCH_
     client:
       # user:
       # token:


### PR DESCRIPTION
supersedes #408

(proposed @carlosms at [#408/issuecomment-446147920](https://github.com/src-d/lookout/pull/408#issuecomment-446147920))

When a newcomer creates the `config.yml` with a copy/paste from `config.yml.tpl` and then runs `lookout`, it will spam **lookout** main repo.

If this PR is merged, the watched repo will be a placeholder, forcing the user to change it with a valid one.

### caveat

Until #385 is addressed (**_If a repo added in config.yml does not exist, CLI is flooded with 404 requests_**) `lookoutd` will flood the output with `404 Not Found` errors:
```shell
lookout_1   | time="2018-12-11T10:36:04.072800623Z" level=error msg="request for PR list failed" app=lookoutd error="github api error: GET https://api.github.com/repos/_USER_/_REPO_TO_TEST_/pulls: 404 Not Found []" repository="_USER_/_REPO_TO_TEST_" response=github.Rate{Limit:5000, Remaining:4825, Reset:github.Timestamp{2018-12-11 10:39:46 +0000 UTC}}
```

### alternative
[discarded by #408] use the fixtures repo `github.com/src-d/lookout-test-fixtures` instead of the `lookout` main one.