### PR TITLE
feature: make lookout-sdk return error code if analysis failed

### DIFF
--- a/cmd/lookout-sdk/push.go
+++ b/cmd/lookout-sdk/push.go
@@ -67,6 +67,7 @@ func (c *PushCommand) Execute(args []string) error {
 		},
 		&store.NoopEventOperator{}, &store.NoopCommentOperator{},
 		0, 0)
+	srv.ExitOnError = true
 
 	log, err := c.repo.Log(&gogit.LogOptions{From: plumbing.NewHash(toRef.Hash)})
 	var commits uint32
@@ -101,11 +102,11 @@ func (c *PushCommand) Execute(args []string) error {
 		},
 		Configuration: conf}, false)
 
+	stopDataServer()
+
 	if err != nil {
 		return err
 	}
-
-	stopDataServer()
 
 	return <-stopCh
 }

--- a/cmd/lookout-sdk/review.go
+++ b/cmd/lookout-sdk/review.go
@@ -63,6 +63,7 @@ func (c *ReviewCommand) Execute(args []string) error {
 		},
 		&store.NoopEventOperator{}, &store.NoopCommentOperator{},
 		0, 0)
+	srv.ExitOnError = true
 
 	id, err := uuid.NewV4()
 	if err != nil {
@@ -82,11 +83,11 @@ func (c *ReviewCommand) Execute(args []string) error {
 		},
 		Configuration: conf}, false)
 
+	stopDataServer()
+
 	if err != nil {
 		return err
 	}
-
-	stopDataServer()
 
 	return <-stopCh
 }

--- a/cmd/sdk-test/bblfsh_test.go
+++ b/cmd/sdk-test/bblfsh_test.go
@@ -47,7 +47,7 @@ func (suite *BblfshIntegrationSuite) RunPush() io.Reader {
 }
 
 func (suite *BblfshIntegrationSuite) TestReviewNoBblfshError() {
-	r := suite.RunCli("review",
+	r := suite.RunCliErr("review",
 		"--bblfshd=ipv4://localhost:0000",
 		"--git-dir="+suite.gitPath,
 		"--from="+logLineRevision.Base.Hash,
@@ -77,7 +77,7 @@ func (suite *BblfshIntegrationSuite) TestReviewLanguage() {
 }
 
 func (suite *BblfshIntegrationSuite) TestPushNoBblfshError() {
-	r := suite.RunCli("push",
+	r := suite.RunCliErr("push",
 		"--bblfshd=ipv4://localhost:0000",
 		"--git-dir="+suite.gitPath,
 		"--from="+logLineRevision.Base.Hash,

--- a/server/server.go
+++ b/server/server.go
@@ -270,6 +270,10 @@ func (s *Server) getConfig(ctx context.Context, e lookout.Event) (map[string]loo
 }
 
 func (s *Server) concurrentRequest(ctx context.Context, conf map[string]lookout.AnalyzerConfig, send reqSent) ([]lookout.AnalyzerComments, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+
 	commentsCh := make(chan *lookout.AnalyzerComments, len(s.analyzers))
 	errCh := make(chan error)
 

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/src-d/lookout"
@@ -30,6 +29,10 @@ type reqSent func(
 
 // Server implements glue between providers / data-server / analyzers
 type Server struct {
+	// ExitOnError set to true would stop the server and return an error
+	// if any analyzer or posting failed
+	ExitOnError bool
+
 	poster     lookout.Poster
 	fileGetter lookout.FileGetter
 	analyzers  map[string]lookout.Analyzer
@@ -51,7 +54,7 @@ func NewServer(
 	reviewTimeout time.Duration,
 	pushTimeout time.Duration,
 ) *Server {
-	return &Server{p, fileGetter, analyzers, eventOp, commentOp, reviewTimeout, pushTimeout}
+	return &Server{false, p, fileGetter, analyzers, eventOp, commentOp, reviewTimeout, pushTimeout}
 }
 
 // HandleEvent processes the event calling the analyzers, and posting the results
@@ -105,7 +108,11 @@ func (s *Server) HandleEvent(ctx context.Context, e lookout.Event) error {
 	}
 
 	// don't fail on event processing error, just skip it
-	return nil
+	if !s.ExitOnError {
+		return nil
+	}
+
+	return err
 }
 
 // HandleReview sends request to analyzers concurrently
@@ -148,7 +155,10 @@ func (s *Server) HandleReview(ctx context.Context, e *lookout.ReviewEvent, safeP
 		}
 		return resp.Comments, nil
 	}
-	comments := s.concurrentRequest(ctx, conf, send)
+	comments, err := s.concurrentRequest(ctx, conf, send)
+	if err != nil {
+		return err
+	}
 
 	if err := s.post(ctx, e, comments, safePosting); err != nil {
 		s.status(ctx, e, lookout.ErrorAnalysisStatus)
@@ -200,7 +210,10 @@ func (s *Server) HandlePush(ctx context.Context, e *lookout.PushEvent, safePosti
 		}
 		return resp.Comments, nil
 	}
-	comments := s.concurrentRequest(ctx, conf, send)
+	comments, err := s.concurrentRequest(ctx, conf, send)
+	if err != nil {
+		return err
+	}
 
 	if err := s.post(ctx, e, comments, safePosting); err != nil {
 		s.status(ctx, e, lookout.ErrorAnalysisStatus)
@@ -256,19 +269,20 @@ func (s *Server) getConfig(ctx context.Context, e lookout.Event) (map[string]loo
 	return res, nil
 }
 
-func (s *Server) concurrentRequest(ctx context.Context, conf map[string]lookout.AnalyzerConfig, send reqSent) []lookout.AnalyzerComments {
-	var comments commentsList
+func (s *Server) concurrentRequest(ctx context.Context, conf map[string]lookout.AnalyzerConfig, send reqSent) ([]lookout.AnalyzerComments, error) {
+	commentsCh := make(chan *lookout.AnalyzerComments, len(s.analyzers))
+	errCh := make(chan error)
 
-	var wg sync.WaitGroup
 	for name, a := range s.analyzers {
 		if a.Config.Disabled || conf[name].Disabled {
 			ctxlog.Get(ctx).Infof("analyzer %s disabled by local .lookout.yml", name)
+			commentsCh <- nil
 			continue
 		}
 
-		wg.Add(1)
 		go func(name string, a lookout.Analyzer) {
-			defer wg.Done()
+			var result *lookout.AnalyzerComments
+			defer func() { commentsCh <- result }()
 
 			aLogger := ctxlog.Get(ctx).With(log.Fields{
 				"analyzer": name,
@@ -279,19 +293,37 @@ func (s *Server) concurrentRequest(ctx context.Context, conf map[string]lookout.
 			cs, err := send(ctx, a.Client, settings)
 			if err != nil {
 				aLogger.Errorf(err, "analysis failed")
+				if s.ExitOnError {
+					errCh <- err
+				}
 				return
 			}
 
 			if len(cs) == 0 {
 				aLogger.Infof("no comments were produced")
+				return
 			}
 
-			comments.Add(a.Config, cs...)
+			result = &lookout.AnalyzerComments{
+				Config:   a.Config,
+				Comments: cs,
+			}
 		}(name, a)
 	}
-	wg.Wait()
 
-	return comments.Get()
+	var comments []lookout.AnalyzerComments
+	for i := 0; i < len(s.analyzers); i++ {
+		select {
+		case err := <-errCh:
+			return nil, err
+		case cs := <-commentsCh:
+			if cs != nil {
+				comments = append(comments, *cs)
+			}
+		}
+	}
+
+	return comments, nil
 }
 
 func mergeSettings(global, local map[string]interface{}) map[string]interface{} {
@@ -375,21 +407,6 @@ func (s *Server) status(ctx context.Context, e lookout.Event, st lookout.Analysi
 	if err := s.poster.Status(ctx, e, st); err != nil {
 		ctxlog.Get(ctx).With(log.Fields{"status": st}).Errorf(err, "posting status failed")
 	}
-}
-
-type commentsList struct {
-	sync.Mutex
-	list []lookout.AnalyzerComments
-}
-
-func (l *commentsList) Add(conf lookout.AnalyzerConfig, cs ...*lookout.Comment) {
-	l.Lock()
-	l.list = append(l.list, lookout.AnalyzerComments{conf, cs})
-	l.Unlock()
-}
-
-func (l *commentsList) Get() []lookout.AnalyzerComments {
-	return l.list
 }
 
 type LogPoster struct {

--- a/util/cmdtest/cmds.go
+++ b/util/cmdtest/cmds.go
@@ -205,6 +205,23 @@ func (suite *IntegrationSuite) IsQueueTested() bool {
 
 // RunCli runs lookout subcommand (not a server)
 func (suite *IntegrationSuite) RunCli(cmd string, args ...string) io.Reader {
+	out, err := suite.runCli(cmd, args...)
+	suite.Require().NoErrorf(err,
+		"'%s %s' command returned error. output:\n%s",
+		cmd, strings.Join(args, " "), out.String())
+
+	return out
+}
+
+// RunCliErr runs lookout subcommand that should fail
+func (suite *IntegrationSuite) RunCliErr(cmd string, args ...string) io.Reader {
+	out, err := suite.runCli(cmd, args...)
+	suite.Require().Error(err, "'%s %s' command should return error", cmd, strings.Join(args, " "))
+
+	return out
+}
+
+func (suite *IntegrationSuite) runCli(cmd string, args ...string) (*bytes.Buffer, error) {
 	args = append([]string{cmd}, args...)
 
 	var out bytes.Buffer
@@ -212,12 +229,7 @@ func (suite *IntegrationSuite) RunCli(cmd string, args ...string) io.Reader {
 	cliCmd.Stdout = &out
 	cliCmd.Stderr = &out
 
-	err := cliCmd.Run()
-	suite.Require().NoErrorf(err,
-		"'lookout %s' command returned error. output:\n%s",
-		strings.Join(args, " "), out.String())
-
-	return &out
+	return &out, cliCmd.Run()
 }
 
 // ResetDB recreates database for the test


### PR DESCRIPTION
I have rewritten concurrentRequest function using channels to be able to
exit as soon as the first analyzer failed.

commentList is also replaced with channel because it's weird to mix
sync package and channels in one function.

fix: https://github.com/src-d/lookout/issues/409

Signed-off-by: Maxim Sukharev <max@smacker.ru>