### PR TITLE
New lookout-sdk --config option

### DIFF
--- a/cmd/sdk-test/args_test.go
+++ b/cmd/sdk-test/args_test.go
@@ -1,0 +1,78 @@
+// +build integration
+
+package sdk_test
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/src-d/lookout/util/cmdtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const dummyConfigFile = "../../fixtures/dummy_config.yml"
+
+type SDKArgsTestSuite struct {
+	SdkIntegrationSuite
+}
+
+func (suite *SDKArgsTestSuite) SetupTest() {
+	suite.StoppableCtx()
+}
+
+func (suite *SDKArgsTestSuite) TearDownTest() {
+	suite.Stop()
+}
+
+func (suite *SDKArgsTestSuite) TestArgs() {
+	suite.StartDummy()
+
+	configArg := fmt.Sprintf("--config=%s", dummyConfigFile)
+
+	mainArgs := []string{
+		"review",
+		"--git-dir=" + suite.gitPath,
+		"--from=" + logLineRevision.Base.Hash,
+		"--to=" + logLineRevision.Head.Hash,
+	}
+
+	lineTestCases := []struct {
+		args []string
+		err  bool
+	}{
+		{[]string{}, false},
+		{[]string{"ipv4://localhost:9930"}, false},
+		{[]string{"--config-json={}"}, false},
+		{[]string{"--config-json={}", "ipv4://localhost:9930"}, false},
+		{[]string{configArg}, false},
+		{[]string{configArg, "ipv4://localhost:9930"}, true},
+		{[]string{configArg, "--config-json={}"}, true},
+		{[]string{configArg, "--config-json={}", "ipv4://localhost:9930"}, true},
+	}
+
+	for _, tc := range lineTestCases {
+		name := fmt.Sprintf("with args %s", strings.Join(tc.args, " "))
+		suite.T().Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			args := append(mainArgs, tc.args...)
+
+			cliCmd := exec.CommandContext(suite.Ctx, cmdtest.LookoutBin, args...)
+			err := cliCmd.Run()
+
+			if tc.err {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestSDKArgsTestSuite(t *testing.T) {
+	suite.Run(t, new(SDKArgsTestSuite))
+}

--- a/util/cmdtest/cmds.go
+++ b/util/cmdtest/cmds.go
@@ -22,8 +22,8 @@ import (
 var CmdTimeout = time.Minute
 
 // default path to binaries
-var dummyBin = "../../build/bin/dummy"
-var lookoutBin = "../../build/bin/lookoutd"
+var DummyBin = "../../build/bin/dummy"
+var LookoutBin = "../../build/bin/lookoutd"
 
 type IntegrationSuite struct {
 	suite.Suite
@@ -36,10 +36,10 @@ type IntegrationSuite struct {
 
 func init() {
 	if os.Getenv("DUMMY_BIN") != "" {
-		dummyBin = os.Getenv("DUMMY_BIN")
+		DummyBin = os.Getenv("DUMMY_BIN")
 	}
 	if os.Getenv("LOOKOUT_BIN") != "" {
-		lookoutBin = os.Getenv("LOOKOUT_BIN")
+		LookoutBin = os.Getenv("LOOKOUT_BIN")
 	}
 }
 
@@ -67,7 +67,7 @@ func (suite *IntegrationSuite) StartDummy(args ...string) io.Reader {
 
 	fmt.Printf("starting dummy %s\n", strings.Join(args, " "))
 
-	cmd := exec.CommandContext(suite.Ctx, dummyBin, args...)
+	cmd := exec.CommandContext(suite.Ctx, DummyBin, args...)
 	cmd.Stdout = outputWriter
 	cmd.Stderr = outputWriter
 
@@ -153,7 +153,7 @@ func (suite *IntegrationSuite) startLookoutd(args ...string) (io.Reader, io.Writ
 	suite.logBuf = &bytes.Buffer{}
 	tee := io.TeeReader(r, suite.logBuf)
 
-	cmd := exec.CommandContext(suite.Ctx, lookoutBin, args...)
+	cmd := exec.CommandContext(suite.Ctx, LookoutBin, args...)
 	cmd.Stdout = outputWriter
 	cmd.Stderr = outputWriter
 
@@ -208,7 +208,7 @@ func (suite *IntegrationSuite) RunCli(cmd string, args ...string) io.Reader {
 	args = append([]string{cmd}, args...)
 
 	var out bytes.Buffer
-	cliCmd := exec.CommandContext(suite.Ctx, lookoutBin, args...)
+	cliCmd := exec.CommandContext(suite.Ctx, LookoutBin, args...)
 	cliCmd.Stdout = &out
 	cliCmd.Stderr = &out
 
@@ -233,7 +233,7 @@ func (suite *IntegrationSuite) ResetDB() {
 	suite.runQuery(db, "GRANT ALL ON SCHEMA public TO public;")
 
 	fmt.Println("running lookoutd migrate")
-	err = exec.Command(lookoutBin, "migrate").Run()
+	err = exec.Command(LookoutBin, "migrate").Run()
 	require.NoError(err, "can't migrate DB")
 }
 


### PR DESCRIPTION
Fix #269.

With this change you can use `--config=./conf.yml`. To avoid confusion on what option has preference over another, what I've done is make it incompatible with `--config-json` and the argument `analyzer`. So if you decide to use a config file, you define everything there: the analyzer address and its settings.

I didn't make any changes to the docs since we are in the middle of the migration to GitBook. If this one gets approved we can open a new issue to add the docs later.