### PR TITLE
Naming lookout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ This repository contains the code of **source{d} Lookout** and the project docum
 
 ## Quickstart
 
-_There are different ways to run **Lookout**; we recommend to use `docker-compose` because it's straightforward, but you can [learn more about the **different ways to run Lookout**](/docs/how-to-run.md)._
+_There are different ways to run **source{d} Lookout**; we recommend to use `docker-compose` because it's straightforward, but you can [learn more about the **different ways to run source{d} Lookout**](/docs/how-to-run.md)._
 
-_Please refer to the [**Configuring source{d} Lookout** guide](/docs/configuration.md) for documentation about the `config.yml` file, and to know how to configure **Lookout** to analyze your repositories, or to use your own analyzers._
+_Please refer to the [**Configuring source{d} Lookout** guide](/docs/configuration.md) for documentation about the `config.yml` file, and to know how to configure **source{d} Lookout** to analyze your repositories, or to use your own analyzers._
 
-Using [Docker Compose](https://docs.docker.com/compose) you can use the provided [`docker-compose.yml`](/docker-compose.yml) config file to start **Lookout**, its dependencies (**bblfsh** and **PostgreSQL**) and a `dummy` analyzer which will add some stats to the watched pull requests.
+Using [Docker Compose](https://docs.docker.com/compose) you can use the provided [`docker-compose.yml`](/docker-compose.yml) config file to start **source{d} Lookout**, its dependencies (**bblfsh** and **PostgreSQL**) and a `dummy` analyzer which will add some stats to the watched pull requests.
 
 To do so, clone this repository or download [`docker-compose.yml`](/docker-compose.yml).
 
@@ -115,7 +115,7 @@ $ docker-compose pull
 $ GITHUB_USER=<user> GITHUB_TOKEN=<token> docker-compose up --force-recreate lookout bblfsh postgres
 ```
 
-If you need to restart the database to a clean state, you must drop the `postgres` container. To do so, stop running **Lookout** with `ctrl+c` and then run:
+If you need to restart the database to a clean state, you must drop the `postgres` container. To do so, stop running **source{d} Lookout** with `ctrl+c` and then run:
 
 ```bash
 $ docker rm lookout_postgres_1
@@ -139,7 +139,7 @@ This is a list of some of the available analyzers for **source{d} Lookout**:
 
 ## Create an Analyzer
 
-If you are developing an Analyzer, or you want more info about how do they work, please check the [documentation about **Lookout** analyzers](/docs/analyzers.md).
+If you are developing an Analyzer, or you want more info about how do they work, please check the [documentation about **source{d} Lookout** analyzers](/docs/analyzers.md).
 
 
 ## Contribute

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -47,7 +47,7 @@ $ make toc
 
 ## Build
 
-You can separately build the binaries provided by **Lookout**; the binaries will be stored under `build/bin` directory.
+You can separately build the binaries provided by **source{d} Lookout**; the binaries will be stored under `build/bin` directory.
 
 ### Server
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 * [Architecture](architecture.md)
 * [Configuration](configuration.md)
-* [How to Run Lookout](how-to-run.md)
+* [How to Run source{d} Lookout](how-to-run.md)
 
 ## Writing an Analyzer
 

--- a/docs/analyzers-creation.md
+++ b/docs/analyzers-creation.md
@@ -20,11 +20,11 @@ You can create a new analyzer in any language that supports protocol buffers, ge
 All the analyzers should consider [the caveats described by the SDK](https://github.com/src-d/lookout-sdk#caveats).
 
 
-## Fetching Changes, UASTs or Languages from Lookout DataService
+## Fetching Changes, UASTs or Languages from DataService
 
-Lookout will take care of dealing with Git repositories, UAST extraction, programming language detection, etc. Your analyzer will be able to use the **DataService** to query all this data.
+**source{d} Lookout** will take care of dealing with Git repositories, UAST extraction, programming language detection, etc. Your analyzer will be able to use the **DataService** to query all this data.
 
-You can read more about it in the [**Lookout Server** section](architecture.md#server).
+You can read more about it in the [**source{d} Lookout Server** section](architecture.md#server).
 
 
 ## How to Test an Analyzer Locally

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -15,12 +15,12 @@ service Analyzer {
 }
 ```
 
-To process the Pull Request, the analyzer can request a stream ([go](https://grpc.io/docs/tutorials/basic/go.html#server-side-streaming-rpc-1), [python](https://grpc.io/docs/tutorials/basic/python.html#response-streaming-rpc)) of files and changes from [**Lookout DataService**](https://github.com/src-d/lookout-sdk/blob/master/proto/lookout/sdk/service_data.proto#L27) that **Lookout** exposes, by default, on `localhost:10301`.
+To process the Pull Request, the analyzer can request a stream ([go](https://grpc.io/docs/tutorials/basic/go.html#server-side-streaming-rpc-1), [python](https://grpc.io/docs/tutorials/basic/python.html#response-streaming-rpc)) of files and changes from [**source{d} Lookout DataService**](https://github.com/src-d/lookout-sdk/blob/master/proto/lookout/sdk/service_data.proto#L27) that **source{d} Lookout** exposes, by default, on `localhost:10301`.
 
 
 ## NotifyReviewEvent
 
-The main responsibility of the Analyzer will be the `NotifyReviewEvent` procedure, called from **Lookout** server when a Pull Requests should be reviewed.
+The main responsibility of the Analyzer will be the `NotifyReviewEvent` procedure, called from **source{d} Lookout** server when a Pull Requests should be reviewed.
 
 The `ReviewEvent` will cause the analysis of the Pull Request by the Analyzer; the result of the analysis will be an `EventResponse` containing the `Comments` to be posted to GitHub.
 
@@ -29,6 +29,6 @@ The `ReviewEvent` will cause the analysis of the Pull Request by the Analyzer; t
 
 _**Important note**: The response for `NotifyPushEvent` allows a series of `Comments`, but this is a placeholder for future functionality. The Analyzer is not expected to return any comment in the current version._
 
-The `NotifyPushEvent` procedure is called from **Lookout** server when there are new commits pushed to any watched repository.
+The `NotifyPushEvent` procedure is called from **source{d} Lookout** server when there are new commits pushed to any watched repository.
 
 The Analyzer is not enforced to do anything with this notification. It could be used, for example, to re-train an internal model using the new contents of the master branch.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,10 @@
 # source{d} Lookout Architecture
 
-![Lookout service sequence diagram](assets/lookout-seq-diagram.png)
+![source{d} Lookout service sequence diagram](assets/lookout-seq-diagram.png)
 
 You can [edit this image](https://mermaidjs.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtXG4gICAgcGFydGljaXBhbnQgR2l0SHViXG4gICAgcGFydGljaXBhbnQgbG9va291dFxuICAgIHBhcnRpY2lwYW50IEFuYWx5emVyXG4gICAgcGFydGljaXBhbnQgQmFiZWxmaXNoXG4gICAgbG9va291dC0-PkdpdEh1YjogUG9sbGluZ1xuICAgIEdpdEh1Yi0tPj5sb29rb3V0OiBQUi9QdXNoIGV2ZW50c1xuICAgIGxvb2tvdXQtPj5BbmFseXplcjogTm90aWZ5UmV2aWV3RXZlbnRcbiAgICBBbmFseXplci0-Pmxvb2tvdXQ6IEdldENoYW5nZXMvR2V0RmlsZXNcbiAgICBsb29rb3V0LT4-QmFiZWxmaXNoOiBwYXJzZUZpbGUgKGlmIFdhbnRVQVNUKVxuICAgIEJhYmVsZmlzaC0tPj5sb29rb3V0OiBVQVNUXG4gICAgbG9va291dC0tPj5BbmFseXplcjogQ2hhbmdlL0ZpbGVcbiAgICBBbmFseXplci0tPj5sb29rb3V0OiBDb21tZW50c1xuICAgIGxvb2tvdXQtPj5HaXRIdWI6IFBvc3QgY29tbWVudHMiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ) using [mermaid](https://mermaidjs.github.io). ([sourcecode](assets/lookout-seq-diagram.md))
 
-Lookout consists of the following components:
+source{d} Lookout consists of the following components:
 
 
 ## Server
@@ -29,6 +29,6 @@ _Find more info about what an analyzer is and how to develop your own analyzer i
 
 An analyzer is a gRPC service that will be called by the [Server](#server) to perform the smart code analysis, and it will return a set of `Comments` as the result of the analysis.
 
-They are not part of **Lookout** repository so they can be developed by third parties.
+They are not part of **source{d} Lookout** repository so they can be developed by third parties.
 
-Lookout Server will call all the registered Analyzers to produce comments for the opened Pull Request in the watched repositories. To register new Analyzers in the configuration file, lookout will need to be restarted.
+source{d} Lookout Server will call all the registered Analyzers to produce comments for the opened Pull Request in the watched repositories. To register new Analyzers in the configuration file, `lookoutd` will need to be restarted.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
-# Configuring Lookout
+# Configuring source{d} Lookout
 
-**Lookout** is configured with the `config.yml` file, you can use the template [`config.yml.tpl`](/config.yml.tpl) to create your own. Use the `lookoutd` option `--config` to set the path to it, or use the default location at `./config.yml`.
+**source{d} Lookout** is configured with the `config.yml` file, you can use the template [`config.yml.tpl`](/config.yml.tpl) to create your own. Use the `lookoutd` option `--config` to set the path to it, or use the default location at `./config.yml`.
 
 The main structure of `config.yml` is:
 
@@ -21,7 +21,7 @@ timeout:
 The most important things you need to configure for a local installation, are:
 
 1. [Repositories](#repositories): add the URLs of the repositories to be watched.
-1. [Analyzers](#analyzers): add the gRPC addresses of the analyzers to be used by Lookout.
+1. [Analyzers](#analyzers): add the gRPC addresses of the analyzers to be used by **source{d} Lookout**.
 
 For more fine grained configuration, you should pay attention to the following documentation.
 
@@ -30,7 +30,7 @@ For more fine grained configuration, you should pay attention to the following d
 
 ## Github Provider
 
-The `providers.github` key configures how **Lookout** will connect with GitHub.
+The `providers.github` key configures how **source{d} Lookout** will connect with GitHub.
 
 ```yaml
 providers:
@@ -47,7 +47,7 @@ providers:
 <a id=basic-auth></a>
 ### Authentication with GitHub
 
-**Lookout** needs to authenticate with GitHub. There are two ways to authenticate with GitHub:
+**source{d} Lookout** needs to authenticate with GitHub. There are two ways to authenticate with GitHub:
 
 - Using GitHub personal access tokens.
 - Authenticating as a GitHub App.
@@ -67,7 +67,7 @@ The credentials can be passed to `lookoutd`:
 <a id=github-app></a>
 #### Authentication as a GitHub App
 
-For a production environment, you can use **Lookout** as a [GitHub App](https://developer.github.com/apps/about-apps/).
+For a production environment, you can use **source{d} Lookout** as a [GitHub App](https://developer.github.com/apps/about-apps/).
 
 To do so, you must also unset any environment variable or option for the GitHub username and token authentication.
 
@@ -97,7 +97,7 @@ The minimum watch interval to discover new pull requests and push events is defi
 
 ## Repositories
 
-The list of repositories to be watched by **Lookout** is defined by:
+The list of repositories to be watched by **source{d} Lookout** is defined by:
 - the `repositories` field at `config.yml`, or
 - the repositories where the GitHub App is installed if you [authenticated as a GitHub App](#github-app). In that case, the `repositories` field in `config.yml` will be ignored.
 
@@ -115,7 +115,7 @@ repositories:
 
 ## Analyzers
 
-Each analyzer to be requested by **Lookout** should be defined under `analyzers` key.
+Each analyzer to be requested by **source{d} Lookout** should be defined under `analyzers` key.
 
 ```yaml
 analyzers:
@@ -132,7 +132,7 @@ analyzers:
 <a id=custom-footer></a>
 ### Add a Custom Message to the Posted Comments
 
-You can configure **Lookout** to add a custom message to every comment that each analyzer returns. This custom message will be created following the rule:
+You can configure **source{d} Lookout** to add a custom message to every comment that each analyzer returns. This custom message will be created following the rule:
 ```
 sprinf(providers.github.comment_footer, feedback)
 ```
@@ -157,11 +157,11 @@ analyzers:
         mode: confident
 ```
 
-The analyzer to configure must be identified with the same `name` in the `.lookout.yml` config file as in **Lookout** server configuration, otherwise, it will be ignored.
+The analyzer to configure must be identified with the same `name` in the `.lookout.yml` config file as in **source{d} Lookout** server configuration, otherwise, it will be ignored.
 
-The repository can disable any analyzer, but it cannot define new analyzers nor enable those that are disabled in the **Lookout** server.
+The repository can disable any analyzer, but it cannot define new analyzers nor enable those that are disabled in the **source{d} Lookout** server.
 
-The `settings` for each analyzer in the `.lookout.yml` config file will be merged with the **Lookout** configuration following these rules:
+The `settings` for each analyzer in the `.lookout.yml` config file will be merged with the **source{d} Lookout** configuration following these rules:
 
 - Objects are deep merged
 - Arrays are replaced
@@ -169,7 +169,7 @@ The `settings` for each analyzer in the `.lookout.yml` config file will be merge
 
 ## Timeouts
 
-The timeouts used by **Lookout** for some operations can be modified or disabled from the `config.yml` file.
+The timeouts used by `lookoutd` for some operations can be modified or disabled from the `config.yml` file.
 
 If any timeout is set to `0`, there will be no timeout for that process.
 

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -1,19 +1,19 @@
-# Running Lookout
+# Running source{d} Lookout
 
 The recommended way to locally try **source{d} Lookout** is using `docker-compose` as described in [quickstart documentation](../README.md#quickstart).
 
-In some situations, you might want to run all its dependencies and components separately, or you may even want to [run it in a distributed mode](#running-lookout-in-distributed-mode). Both ways to run **Lookout** would require to follow these general steps:
+In some situations, you might want to run all its dependencies and components separately, or you may even want to [run it in a distributed mode](#running-lookout-in-distributed-mode). Both ways to run **source{d} Lookout** would require to follow these general steps:
 
-1. [Run Lookout dependencies](#dependencies).
+1. [Run source{d} Lookout dependencies](#dependencies).
 1. [Run the desired analyzers](#run-the-analyzers).
-1. [Configure Lookout](#configure-lookout).
-1. [Run Lookout](#run-lookout).
+1. [Configure source{d} Lookout](#configure-lookout).
+1. [Run source{d} Lookout](#run-lookout).
 
 In other situations you may just want to test an analyzer locally without accessing GitHub at all. For those situations, you might want to read the [`lookout-sdk` binary documentation](lookout-sdk.md).
 
-## Running Lookout in Distributed Mode
+## Running source{d} Lookout in Distributed Mode
 
-Lookout can be also run in a distributed fashion using a [RabbitMQ](https://www.rabbitmq.com/) queue to coordinate a _watcher_ and several _workers_.
+**source{d} Lookout** can be also run in a distributed fashion using a [RabbitMQ](https://www.rabbitmq.com/) queue to coordinate a _watcher_ and several _workers_.
 
 - The _watcher_ process monitors GitHub pull requests and enqueues jobs for new events.
 - The running _workers_ dequeue jobs as they become available, call the registered analyzers, and post the results as comments.
@@ -23,11 +23,11 @@ The general steps to run source{d} Lookout in distributed mode are the same as s
 
 # Dependencies
 
-**Lookout** needs a running instance of:
+**source{d} Lookout** needs a running instance of:
 
 * [bblfshd](https://github.com/bblfsh/bblfshd) to parse files into [UAST](https://doc.bblf.sh/uast/uast-specification.html).
 * [PostgreSQL](https://www.postgresql.org) for persistence.
-* (**optional**) [RabbitMQ](https://www.rabbitmq.com) to coordinate a _watcher_ and several _workers_ (when running **Lookout** in a distributed way).
+* (**optional**) [RabbitMQ](https://www.rabbitmq.com) to coordinate a _watcher_ and several _workers_ (when running **source{d} Lookout** in a distributed way).
 
 You can run them manually or with `docker-compose`.
 
@@ -45,7 +45,7 @@ To monitor RabbitMQ, go to http://localhost:8081, and access it with `guest/gues
 
 # Run the Analyzers
 
-You will need to run the Analyzers to be used by **Lookout**.
+You will need to run the Analyzers to be used by **source{d} Lookout**.
 
 You can run one of our [example analyzers](analyzers-examples.md), any of the already [available analyzers](../README.md#available-analyzers) or the one that you're developing.
 
@@ -55,11 +55,11 @@ For testing purposes, you may want to use a *dummy* analyzer. You can do so down
 $ dummy serve
 ```
 
-# Configure Lookout
+# Configure source{d} Lookout
 
 Copy the [`config.yml.tpl`](/config.yml.tpl) into `config.yml` and modify it according to your needs.
 
-Take a look at [configuration and GitHub authentication](configuration.md) for more details about **Lookout** configuration.
+Take a look at [configuration and GitHub authentication](configuration.md) for more details about **source{d} Lookout** configuration.
 
 At least you should:
 
@@ -67,9 +67,9 @@ At least you should:
 1. Add the URLs of the repositories to be watched or authenticate as a GitHub App.
 
 
-# Run Lookout
+# Run source{d} Lookout
 
-Download the latest `lookoutd` binary from [**Lookout** releases page](https://github.com/src-d/lookout/releases).
+Download the latest `lookoutd` binary from [**source{d} Lookout** releases page](https://github.com/src-d/lookout/releases).
 
 ## Initialize the Database
 
@@ -79,7 +79,7 @@ _For non-default configuration, please take a look into [**`lookoutd` Command Op
 $ lookoutd migrate
 ```
 
-## Start Lookout
+## Start source{d} Lookout
 
 _For non-default configuration, please take a look into [**`lookoutd` Command Options**](#options)_
 
@@ -149,7 +149,7 @@ You can adjust the number of events that each _worker_ or the single _server_ wi
 
 ## Dependencies URIs
 
-If you started all the **Lookout** dependencies using `docker-compose`, then `lookoutd` binary will be able to find them with its default values; otherwise, you should pass some extra values when running the `lookoutd` binary:
+If you started all the **source{d} Lookout** dependencies using `docker-compose`, then `lookoutd` binary will be able to find them with its default values; otherwise, you should pass some extra values when running the `lookoutd` binary:
 
 | subcommands | Env var | Option | Description | Default |
 | --- | --- | --- | --- | --- |

--- a/docs/lookout-sdk.md
+++ b/docs/lookout-sdk.md
@@ -2,13 +2,13 @@
 
 _For the **lookout-sdk** library to develop new analyzers go to [**lookout-sdk**](https://github.com/src-d/lookout-sdk) repository._
 
-`lookout-sdk` binary is a simplified version of the **Lookout** server that works with a local git repository and does not need access to Github.
+`lookout-sdk` binary is a simplified version of the `lookoutd` server that works with a local git repository and does not need access to Github.
 
-You can think about `lookout-sdk` as a _curl-like_ tool to call an analyzer gRPC endpoint with a `ReviewEvent` or a `PushEvent`, from a local git repository, and send it to an analyzer without accessing GitHub at all. For convenience, `lookout-sdk` also exposes a **Lookout DataService** backed by the same git repository.
+You can think about `lookout-sdk` as a _curl-like_ tool to call an analyzer gRPC endpoint with a `ReviewEvent` or a `PushEvent`, from a local git repository, and send it to an analyzer without accessing GitHub at all. For convenience, `lookout-sdk` also exposes a **source{d} Lookout DataService** backed by the same git repository.
 
 You can download the latest `lookout-sdk` from the [src-d/lookout releases page](https://github.com/src-d/lookout/releases).
 
-This is the sequence diagram of the `ReviewEvent` made by `lookout-sdk review`. You can compare it with a regular **Lookout** installation at the [**source{d} Lookout architecture** documentation](architecture.md).
+This is the sequence diagram of the `ReviewEvent` made by `lookout-sdk review`. You can compare it with a regular **source{d} Lookout** installation at the [Architecture documentation](architecture.md).
 
 ![sequence diagram](assets/lookout-sdk-seq-diagram.png)
 
@@ -30,12 +30,12 @@ This will create the [bblfshd](https://github.com/bblfsh/bblfshd) container list
 
 ## Usage
 
-To perform a `NotifyReviewEvent` call to an analyzer and serve the **Lookout DataService** endpoint, run:
+To perform a `NotifyReviewEvent` call to an analyzer and serve the **source{d} Lookout DataService** endpoint, run:
 ```shell
 $ lookout-sdk review
 ```
 
-To perform a `NotifyPushEvent` call to an analyzer and serve the **Lookout DataService** endpoint, run:
+To perform a `NotifyPushEvent` call to an analyzer and serve the **source{d} Lookout DataService** endpoint, run:
 ```shell
 $ lookout-sdk push
 ```
@@ -75,11 +75,11 @@ $ lookout-sdk review \
 
 Doing so, `lookout-sdk` will:
 
-1. start a gRPC **Lookout DataService** endpoint backed by the repository stored at `/somewhere/repo/path`;
+1. start a gRPC **source{d} Lookout DataService** endpoint backed by the repository stored at `/somewhere/repo/path`;
 1. create a `ReviewEvent` with the changes between `branch-b` and `branch-a`;
 1. send a gRPC `NotifyReviewEvent` call to your analyzer listening on `ipv4://localhost:9999` with the created `ReviewEvent`;
-1. wait till the analyzer sends a response with the comments; the analyzer will be able to request file contents, file language or UASTs to the gRPC **Lookout DataService** endpoint exposed by `lookout-sdk`;
-1. once the analyzer sends the response, `lookout-sdk` will put it into the `STDOUT`, stop the **Lookout DataService** and exit.
+1. wait till the analyzer sends a response with the comments; the analyzer will be able to request file contents, file language or UASTs to the gRPC **source{d} Lookout DataService** endpoint exposed by `lookout-sdk`;
+1. once the analyzer sends the response, `lookout-sdk` will put it into the `STDOUT`, stop the **source{d} Lookout DataService** and exit.
 
 _For more options to run `lookout-sdk`, take a look into [**lookout-sdk Command Options**](#options)_
 


### PR DESCRIPTION
depends on #398 and #423

In this commit 10e9bcb I tried to fix all occurrences of `Lookout` in `.md` files, replacing them with `source{d} Lookout` according to our **source{d} Lookout** naming conventions

To do so, I used `/(?<!\{d\}\s|[\.\/``-])Lookout(?!-sdk|d|_)/gi` ([example](https://regex101.com/r/rN1z5o/3)), to find all `lookout` ocurrences not being:
- precedeb by:
  - `{d} ` (e.g. `source{d} Lookout`)
  - `.` (e.g. `.lookout.yml`)
  - `/` (e.g. `/path/to/lookout`)
  - ` `` ` (e.g. ` ``lookout`` `)
  - `-` (e.g. `#configure-lookout`)
- followed by:
  - `-sdk` (e.g. `lookout-sdk`)
  - `d` (e.g. `lookoutd`)
  - `_` (e.g. `LOOKOUT_DATA_SERVER`)
