### PR TITLE
Remove web build from main makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,12 @@ jobs:
       os: osx
       osx_image: xcode9.4
       before_install: skip
+    - name: 'Web Tests'
+      stage: tests
+      script:
+        - make dependencies
+        - make -f Makefile.web build
+        - make -f Makefile.web test
     - name: 'Generated code'
       script:
         - make dependencies

--- a/Makefile
+++ b/Makefile
@@ -130,14 +130,3 @@ endif
 .PHONY: ci-integration-dependencies
 ci-integration-dependencies: prepare-services ci-start-bblfsh
 
-# Redefine targets from main Makefile to support web
-
--include Makefile.web
-
-# Makefile.main::test -> this::test
-test: web-test
-
-# this::build -> Makefile.main::build -> Makefile.main::$(COMMANDS)
-# The @echo forces this prerequisites to be run before `Makefile.main::build` ones.
-build: web-build web-bindata
-	@echo

--- a/Makefile.web
+++ b/Makefile.web
@@ -1,3 +1,15 @@
+# Redefine targets from main Makefile
+
+-include Makefile
+
+# Makefile.main::test -> this::test
+test: web-test
+
+# this::build -> Makefile.main::build -> Makefile.main::$(COMMANDS)
+# The @echo forces this prerequisites to be run before `Makefile.main::build` ones.
+build: web-build web-bindata
+	@echo
+
 FRONTEND_PATH := ./frontend
 FRONTEND_BUILD_PATH := $(FRONTEND_PATH)/build
 


### PR DESCRIPTION
Currently, drone builds are broken because `yarn` is missing in the image we use to build.

Instead of fixing the build, I thought it made sense to remove the web targets from the main makefile for now, until web is more stable and we want to include it in the released binary.
A normal `make build` will still create the `lookoutd web` server, but accessing returns 404.

The web targets can be used like this:
```
make -f Makefile.web build
make -f Makefile.web web-start
```