### PR TITLE
Improve web config file error messages

### DIFF
--- a/cmd/lookoutd/web.go
+++ b/cmd/lookoutd/web.go
@@ -50,13 +50,13 @@ func (c *WebCommand) Execute(args []string) error {
 
 	ghConfg := conf.Providers.Github
 	if ghConfg.ClientID == "" {
-		return fmt.Errorf("provider github client_id is required")
+		return fmt.Errorf("Missing field in configuration file: provider github client_id is required")
 	}
 	if ghConfg.ClientSecret == "" {
-		return fmt.Errorf("provider github client_secret is required")
+		return fmt.Errorf("Missing field in configuration file: provider github client_secret is required")
 	}
 	if conf.Web.SigningKey == "" {
-		return fmt.Errorf("web signing_key is required")
+		return fmt.Errorf("Missing field in configuration file: web signing_key is required")
 	}
 
 	auth := web.NewAuth(ghConfg.ClientID, ghConfg.ClientSecret, conf.Web.SigningKey)


### PR DESCRIPTION
With the current error in master, you get this, which is not so obvious:
```console
$ ./build/bin/lookoutd web 
provider github client_id is required
```