### PR TITLE
List user's organizations in web

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -2,13 +2,13 @@
 
 *Work in progress*
 
-source{d} Lookout web interface provides user friendly way to configure Github installations by users.
+source{d} Lookout web interface provides a user friendly way to configure GitHub installations by users.
 
 ### Configuration
 
-The web interface requires usage of Github App as authorization method and requires GitHub App OAuth credentials.
+The web interface requires the usage of a Github App as authorization method, and requires GitHub App OAuth credentials.
 
-Please, follow an instraction how to get them in [main configuration guide](fix_this_link_later) and set them in `config.yaml` as following:
+Please follow the instructions on how to get them in the [main configuration guide](configuration.md), and set them in `config.yaml` as follows:
 
 ```yaml
 providers:
@@ -29,8 +29,12 @@ It can be any non-empty string.
 ```yaml
 web:
   # Secret key to sign JSON Web Tokens
-  signing_key:
+  signing_key: secret123
 ```
+
+There is one extra requirement. In order to identify who is an administrator, the source{d} Lookout GitHub App needs to define one extra permission:
+
+- Organization members: Read-only
 
 #### Advanced configuration
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -9,7 +9,7 @@
 
 .App-header {
   background-color: #282c34;
-  min-height: 100vh;
+  min-height: 150px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import './App.css';
 import Callback from './Callback';
 import Loader from './components/Loader';
+import Organizations from './components/Organizations';
 import Auth, { User } from './services/auth';
 
 function Login() {
@@ -34,9 +35,12 @@ interface IndexProps {
 
 function Index({ user }: IndexProps) {
   return (
-    <header className="App-header">
-      Hello {user.name}! <Link to="/logout">Logout</Link>
-    </header>
+    <div>
+      <header className="App-header">
+        Hello {user.name}! <Link to="/logout">Logout</Link>
+      </header>
+      <Organizations user={user} />
+    </div>
   );
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -80,3 +80,15 @@ interface MeResponse {
 export function me(): Promise<MeResponse> {
   return apiCall<MeResponse>('/api/me');
 }
+
+export interface Org {
+  name: string;
+}
+
+interface OrgsResponse extends Array<Org> {}
+
+// Returns a list of GitHub organization names where lookout is installed and
+// the logged-in user is an administrator
+export function orgs(): Promise<OrgsResponse> {
+  return apiCall<OrgsResponse>('/api/orgs');
+}

--- a/frontend/src/components/Organizations.tsx
+++ b/frontend/src/components/Organizations.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import * as api from '../api';
+import { User } from '../services/auth';
+import Errors from './Errors';
+import Loader from './Loader';
+
+interface OrgsProps {
+  user: User;
+}
+
+interface OrgsState {
+  done: boolean;
+  orgs: api.Org[];
+  errors: string[];
+}
+
+class Organizations extends React.Component<OrgsProps, OrgsState> {
+  public state: OrgsState = {
+    done: false,
+    orgs: [],
+    errors: []
+  };
+
+  public componentDidMount() {
+    return api
+      .orgs()
+      .then(resp => {
+        this.setState({
+          done: true,
+          orgs: resp,
+          errors: []
+        });
+      })
+      .catch(err => {
+        this.setState({
+          done: true,
+          orgs: [],
+          errors: err
+        });
+      });
+  }
+
+  public render() {
+    if (!this.state.done) {
+      return <Loader />;
+    }
+
+    if (this.state.errors.length > 0) {
+      return <Errors errors={this.state.errors} />;
+    }
+
+    const orgs = this.state.orgs.map(org => <li key={org.name}>{org.name}</li>);
+
+    return (
+      <div>
+        <h1>
+          Organizations with source
+          {'{d}'} Lookout installed where {this.props.user.name} is admin:
+        </h1>
+        <ul>{orgs}</ul>
+      </div>
+    );
+  }
+}
+
+export default Organizations;

--- a/web/github.go
+++ b/web/github.go
@@ -1,0 +1,114 @@
+package web
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bradleyfalzon/ghinstallation"
+	"github.com/google/go-github/github"
+	"github.com/src-d/lookout/util/ctxlog"
+)
+
+// GitHub is an HTTP service to call GitHub endpoints
+type GitHub struct {
+	AppID      int
+	PrivateKey string
+}
+
+func (g *GitHub) installations(ctx context.Context) ([]*github.Installation, error) {
+	appTr, err := ghinstallation.NewAppsTransportKeyFromFile(
+		http.DefaultTransport, g.AppID, g.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	appClient := github.NewClient(&http.Client{Transport: appTr})
+
+	var installations []*github.Installation
+	opts := &github.ListOptions{
+		PerPage: 100,
+	}
+	for {
+		installs, resp, err := appClient.Apps.ListInstallations(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		installations = append(installations, installs...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.Page = resp.NextPage
+	}
+
+	return installations, nil
+}
+
+// orgResponse is the response type used by Orgs handler
+type orgRespose struct {
+	Name string `json:"name"`
+}
+
+// Orgs writes in the response the list of organizations where the
+// logged-in user is an admin
+func (g *GitHub) Orgs(w http.ResponseWriter, r *http.Request) {
+	login, err := GetUserLogin(r.Context())
+	if err != nil {
+		ctxlog.Get(r.Context()).Errorf(err, "failed to get user login from context")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	installations, err := g.installations(r.Context())
+	if err != nil {
+		ctxlog.Get(r.Context()).Errorf(err, "failed to retrieve the GitHub App installations")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// initialized as empty array because otherwise json response will be null
+	// instead of []
+	orgs := []orgRespose{}
+
+	for _, installation := range installations {
+		// New transport for each installation
+		itr, err := ghinstallation.NewKeyFromFile(
+			http.DefaultTransport, g.AppID, int(installation.GetID()), g.PrivateKey)
+
+		if err != nil {
+			ctxlog.Get(r.Context()).Errorf(err, "failed to initialize the GitHub App installation client")
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		// Use installation transport in a new client
+		client := github.NewClient(&http.Client{Transport: itr})
+
+		if installation.Account == nil || installation.Account.Login == nil {
+			ctxlog.Get(r.Context()).Errorf(nil, "failed to get GitHub installation organization name")
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		// a GitHub App can also be installed in a User account
+		if *installation.Account.Type != "Organization" {
+			continue
+		}
+
+		org := *installation.Account.Login
+		mem, _, err := client.Organizations.GetOrgMembership(r.Context(), login, org)
+		if err != nil {
+			ctxlog.Get(r.Context()).Errorf(err, "failed to get GitHub user %s membership to organization %s: ", login, org)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		if *mem.Role == "admin" {
+			orgs = append(orgs, orgRespose{Name: org})
+		}
+	}
+
+	successJSON(w, r, orgs)
+}

--- a/web/http_server.go
+++ b/web/http_server.go
@@ -12,7 +12,7 @@ type HTTPServer struct {
 	mux http.Handler
 }
 
-func NewHTTPServer(auth *Auth, static *Static) *HTTPServer {
+func NewHTTPServer(auth *Auth, gh *GitHub, static *Static) *HTTPServer {
 	corsOptions := cors.Options{
 		// TODO: make it customizable
 		// we can't pass "*" because it's incompatible with "credentials: include" request
@@ -36,6 +36,7 @@ func NewHTTPServer(auth *Auth, static *Static) *HTTPServer {
 	r.Get("/api/callback", auth.Callback)
 	r.With(auth.Middleware).Route("/api", func(r chi.Router) {
 		r.Get("/me", auth.Me)
+		r.Get("/orgs", gh.Orgs)
 	})
 	r.Get("/static/*", static.ServeHTTP)
 	r.Get("/*", static.ServeHTTP)


### PR DESCRIPTION
Fix #400.

This PR is as simple as possible. The UI is of course not much more than a place holder.

For the backend, I reused the existing json responses. [There is a comment](https://github.com/src-d/lookout/blob/master/web/auth.go#L20) to extend them into separate responses once we have more endpoints, but I thought it made sense to keep this PR small and do that later; possible when we have more endpoints and see the need more clearly.

There are possibly other optimizations that could be done in the backend, but for this PR I chose to ignore them. I'm talking about things like adding a cache for the list of installations, or even the list of organizations for a given user.