### PR TITLE
WIP Tangle Implicit Rule FIXED

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ jobs:
         - make dependencies
         - make -f Makefile.web build
         - make -f Makefile.web test
+        - make -f Makefile.web lint
     - name: 'Generated code'
       script:
         - make dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,97 +25,14 @@ before_install:
 
 stages:
   - name: tests
-  - name: release
-    if: tag IS present AND NOT tag =~ /^dummy/
-  - name: release dummy analyzer
-    if: tag IS present AND tag =~ /^dummy/
 
 jobs:
   include:
-    - name: 'Unit Tests'
-      stage: tests
-      script: make test-coverage codecov
-    - name: 'Tool Integration Tests Linux'
-      script:
-        - make ci-start-bblfsh
-        - make test-tool
-    - name: 'Tool Integration Tests macOS'
-      if: NOT type = pull_request
-      script:
-        - make test-tool-short
-      os: osx
-      osx_image: xcode9.4
-      before_install: skip
-    - name: 'Lookoutd Integration Tests Linux'
-      script:
-        - make ci-integration-dependencies
-        - psql -c 'create database lookout;' -U postgres
-        - make test-json
-        - LOOKOUT_TEST_QUEUE=true make test-json
-    - name: 'Lookoutd Integration Tests macOS'
-      if: NOT type = pull_request
-      script:
-        - make ci-integration-dependencies
-        - psql -c 'create database lookout;' -U postgres
-        - make test-json
-        - LOOKOUT_TEST_QUEUE=true make test-json
-      os: osx
-      osx_image: xcode9.4
-      before_install: skip
-    - name: 'Web Tests'
+    - name: 'Test Coverage'
       stage: tests
       script:
-        - make dependencies
-        - make -f Makefile.web build
-        - make -f Makefile.web test
-        - make -f Makefile.web lint
-    - name: 'Generated code'
-      script:
-        - make dependencies
-        - go generate ./...
-        - make no-changes-in-commit
-        - kallax migrate --input ./store/models/ --out ./store/migrations --name test-changes
-        - make no-changes-in-commit
-        - make pack-migrations
-        - make no-changes-in-commit
-        - make build
-        - make no-changes-in-commit
-        - make godep
-        - make no-changes-in-commit
-    - name: 'linux packages'
-      stage: release
-      script:
-        - PKG_OS="linux" make packages
-        - PKG_OS="linux" make -f Makefile.tool packages
-        - PKG_OS="linux" make -f Makefile.dummy packages
-      deploy: &deploy_anchor
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file_glob: true
-        file: build/*.tar.gz
-        skip_cleanup: true
-        on:
-          all_branches: true
-    - name: 'macOS packages'
-      stage: release
-      os: osx
-      osx_image: xcode9.4
-      before_install: skip
-      script:
-        - PKG_OS="darwin" make packages
-        - PKG_OS="darwin" make -f Makefile.tool packages
-        - PKG_OS="darwin" make -f Makefile.dummy packages
-      deploy: *deploy_anchor
-    - name: 'push image to Docker Hub'
-      stage: release
-      script:
-        - PKG_OS=linux make build
-        - DOCKER_PUSH_LATEST=true make docker-push
-    - name: 'push dummy analyzer image to Docker Hub'
-      stage: release dummy analyzer
-      script:
-        - PKG_OS=linux make -f Makefile.dummy build
-        - DOCKER_PUSH_LATEST=true make -f Makefile.dummy docker-push
+        - rm -rf .ci/; touch Makefile.web;
+        - make test-coverage codecov
 before_cache:
   # make bblfsh images readable
   - sudo chmod -R 777 $HOME/bblfshd/images

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ DEPENDENCIES = \
 	gopkg.in/src-d/go-kallax.v1 \
 	github.com/mjibson/esc
 
+# Deletes all the extensions using make implicit rules
+.SUFFIXES:
+
 # Backend services
 POSTGRESQL_VERSION = 9.6
 RABBITMQ_VERSION=any

--- a/Makefile.web
+++ b/Makefile.web
@@ -68,3 +68,7 @@ web-start:
 
 .PHONY: web-serve
 web-serve: | web-dependencies web-build web-pack web-start
+
+.PHONY: lint
+lint:
+	$(YARN) lint

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@types/node": "^10.12.15",
     "@types/react": "^16.7.17",
     "@types/react-dom": "^16.0.11",
+    "history": "^4.7.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-router-dom": "^4.3.1",
@@ -17,7 +18,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "tslint -p .",
+    "format": "tslint -p . --fix"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -30,6 +33,10 @@
   ],
   "devDependencies": {
     "@types/react-router-dom": "^4.3.1",
-    "jest-fetch-mock": "^2.1.0"
+    "jest-fetch-mock": "^2.1.0",
+    "tslint": "^5.12.0",
+    "tslint-config-prettier": "^1.17.0",
+    "tslint-plugin-prettier": "^2.0.1",
+    "tslint-react": "^3.6.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,17 +1,16 @@
 import React, { Component } from 'react';
 import {
   BrowserRouter as Router,
-  Route,
-  Redirect,
   Link,
-  RouteProps,
-  RouteComponentProps
+  Redirect,
+  Route,
+  RouteComponentProps,
+  RouteProps
 } from 'react-router-dom';
-import { User } from './services/auth';
-import Auth from './services/auth';
-import Loader from './components/Loader';
-import Callback from './Callback';
 import './App.css';
+import Callback from './Callback';
+import Loader from './components/Loader';
+import Auth, { User } from './services/auth';
 
 function Login() {
   return (
@@ -66,20 +65,21 @@ function PrivateRoute({ component, ...rest }: PrivateRouteProps) {
       this.state = { isAuthenticated: undefined };
     }
 
-    componentDidMount() {
+    public componentDidMount() {
       Auth.isAuthenticated
         .then(ok => this.setState({ isAuthenticated: ok }))
         .catch(() => this.setState({ isAuthenticated: false }));
     }
 
-    render() {
+    public render() {
       if (!component) {
         return null;
       }
 
       if (this.state.isAuthenticated === true) {
-        const Component = component;
-        return <Component {...this.props} user={Auth.user} />;
+        // tslint:disable-next-line
+        const WrappedComponent = component; // must be uppercase because of JSX
+        return <WrappedComponent {...this.props} user={Auth.user} />;
       }
 
       if (this.state.isAuthenticated === false) {
@@ -104,7 +104,7 @@ function AppRouter() {
   return (
     <Router>
       <div className="App">
-        <PrivateRoute path="/" exact component={Index} />
+        <PrivateRoute path="/" exact={true} component={Index} />
         <Route path="/login" component={Login} />
         <Route path="/logout" component={Logout} />
         <Route path="/callback" component={Callback} />

--- a/frontend/src/Callback.tsx
+++ b/frontend/src/Callback.tsx
@@ -1,10 +1,10 @@
+import * as H from 'history';
 import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
-import * as H from 'history';
-import Auth from './services/auth';
 import * as api from './api';
-import Loader from './components/Loader';
 import Errors from './components/Errors';
+import Loader from './components/Loader';
+import Auth from './services/auth';
 
 interface CallbackProps {
   location: H.Location;
@@ -25,13 +25,13 @@ class Callback extends Component<CallbackProps, CallbackState> {
     };
   }
 
-  componentDidMount() {
+  public componentDidMount() {
     Auth.callback(this.props.location.search)
       .then(() => this.setState({ success: true }))
       .catch(errors => this.setState({ errors }));
   }
 
-  render() {
+  public render() {
     const { errors, success } = this.state;
 
     if (errors.length) {

--- a/frontend/src/api.test.tsx
+++ b/frontend/src/api.test.tsx
@@ -1,10 +1,11 @@
 import { GlobalWithFetchMock } from 'jest-fetch-mock';
-import Auth from './services/auth';
 import { apiCall } from './api';
+import Auth from './services/auth';
 
 // can be moved to setupFiles later if needed
 const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
-customGlobal.fetch = require('jest-fetch-mock');
+// tslint:disable-next-line
+customGlobal.fetch = require('jest-fetch-mock'); // import * as X raises types error
 customGlobal.fetchMock = customGlobal.fetch;
 
 describe('api', () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,5 @@
-import lookoutOptions from './services/options';
 import Auth from './services/auth';
+import lookoutOptions from './services/options';
 
 export const serverUrl = lookoutOptions.SERVER_URL || 'http://127.0.0.1:8080';
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
 import App from './App';
+import './index.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -26,6 +26,7 @@ class AuthService {
           return true;
         })
         .catch(err => {
+          // tslint:disable-next-line
           console.error(err);
           this._user = null;
           return false;
@@ -43,13 +44,13 @@ class AuthService {
     return api.loginUrl;
   }
 
-  callback(queryString: string) {
+  public callback(queryString: string) {
     return api.callback(location.search).then(resp => {
       window.localStorage.setItem(localStorageKey, resp.token);
     });
   }
 
-  logout(): void {
+  public logout(): void {
     window.localStorage.removeItem(localStorageKey);
   }
 }

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -1,0 +1,18 @@
+{
+  "defaultSeverity": "error",
+  "extends": ["tslint:latest", "tslint-react", "tslint-config-prettier"],
+  "jsRules": {},
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "object-literal-sort-keys": false,
+    "no-implicit-dependencies": [true, "dev"],
+    "variable-name": [
+      true,
+      "ban-keywords",
+      "check-format",
+      "allow-leading-underscore"
+    ],
+    "prettier": true
+  },
+  "rulesDirectory": ["tslint-plugin-prettier"]
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1909,7 +1909,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
@@ -2050,7 +2050,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
+chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -2264,7 +2264,7 @@ commander@2.17.x, commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.11.0:
+commander@^2.11.0, commander@^2.12.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -3269,6 +3269,14 @@ eslint-plugin-jsx-a11y@6.1.2:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-prettier@^2.2.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
+  integrity sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-plugin-react@7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
@@ -3612,6 +3620,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.3"
@@ -5173,6 +5186,11 @@ jest-diff@^23.6.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
 
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+  integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
+
 jest-docblock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
@@ -5706,6 +5724,11 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -9165,10 +9188,56 @@ tryer@^1.0.0:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslint-config-prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz#946ed6117f98f3659a65848279156d87628c33dc"
+  integrity sha512-NKWNkThwqE4Snn4Cm6SZB7lV5RMDDFsBwz6fWUkTxOKGjMx8ycOHnjIbhn7dZd5XmssW3CwqUjlANR6EhP9YQw==
+
+tslint-plugin-prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz#95b6a3b766622ffc44375825d7760225c50c3680"
+  integrity sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==
+  dependencies:
+    eslint-plugin-prettier "^2.2.0"
+    lines-and-columns "^1.1.6"
+    tslib "^1.7.1"
+
+tslint-react@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.6.0.tgz#7f462c95c4a0afaae82507f06517ff02942196a1"
+  integrity sha512-AIv1QcsSnj7e9pFir6cJ6vIncTqxfqeFF3Lzh8SuuBljueYzEAtByuB6zMaD27BL0xhMEqsZ9s5eHuCONydjBw==
+  dependencies:
+    tsutils "^2.13.1"
+
+tslint@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.0.tgz#47f2dba291ed3d580752d109866fb640768fca36"
+  integrity sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.27.2"
+
+tsutils@^2.13.1, tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
solves the bug found by https://github.com/src-d/lookout/pull/446

If the `Makefile.web` is newer than `Makefilep`, and `make` runs its _implicit rules_, it will fail;
thanks to 236ca4e the _implicit rule_ about `Makefile.web` is not run.
