### PR TITLE
Fix callback test

### DIFF
--- a/web/auth_test.go
+++ b/web/auth_test.go
@@ -68,7 +68,7 @@ func TestCallbackSuccess(t *testing.T) {
 	code := "test-code"
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/callback?state="+state+"&code="+code, nil)
+	r := httptest.NewRequest("GET", "/api/callback?state="+state+"&code="+code, nil)
 
 	session, _ := auth.store.Get(r, "sess")
 	session.Values["state"] = state


### PR DESCRIPTION
It does not matter the URL wrote in the Request because the callback handler is called directly and it does not check the URL called, but it is still needed to point to the right URL when testing the callback.