### PR TITLE
Let web-start work without assets

### DIFF
--- a/Makefile.web
+++ b/Makefile.web
@@ -27,10 +27,8 @@ MKDIR := mkdir -p
 
 # Environment and arguments to use in `go run` calls.
 GO_RUN_ENV := LOG_LEVEL=DEBUG
-GO_RUN_ARGS += -tags "$(WITH_STATIC_TAG)"
 
 GOCMD = go
-GORUN = $(GOCMD) run $(GO_RUN_ARGS)
 
 build-path:
 	$(MKDIR) $(BUILD_PATH)
@@ -64,10 +62,11 @@ web-pack:
 
 .PHONY: web-start
 web-start:
-	$(GO_RUN_ENV) $(GORUN) cmd/lookoutd/*.go web
+	$(GO_RUN_ENV) $(GOCMD) run cmd/lookoutd/*.go web
 
 .PHONY: web-serve
-web-serve: | web-dependencies web-build web-bindata web-start
+web-serve: | web-build web-pack
+	$(GO_RUN_ENV) $(GOCMD) run -tags "$(WITH_STATIC_TAG)" cmd/lookoutd/*.go web
 
 .PHONY: lint
 lint:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -104,7 +104,7 @@ In case you want to locally run the web interface from sources, you can choose o
     ```shell
     $ make -f Makefile.web web-serve
     ```
-    And navigate to [http://127.0.0.0:8080](http://127.0.0.0:8080)
+    And navigate to [http://127.0.0.1:8080](http://127.0.0.1:8080)
 - using `create-react-app` dev server, with live reload for web assets changes, running in separated terminals the backend: 
     ```shell
     $ make -f Makefile.web web-start
@@ -114,7 +114,7 @@ In case you want to locally run the web interface from sources, you can choose o
     $ make -f Makefile.web web-dependencies # if you didn't do it yet
     $ yarn --cwd frontend start
     ```
-    Configure the GitHub App authorization callback URL to `http://127.0.0.0:3000/callback`, and navigate to [http://127.0.0.0:3000](http://127.0.0.0:3000)
+    Configure the GitHub App authorization callback URL to `http://127.0.0.1:3000/callback`, and navigate to [http://127.0.0.1:3000](http://127.0.0.1:3000)
 
 ### Testing
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -23,7 +23,7 @@ Open [http://127.0.0.1:8080](http://127.0.0.1:8080) in your browser.
 
 The web interface requires the usage of a Github App as authorization method, and requires GitHub App OAuth credentials.
 
-The GitHub App authorization callback must be processed by the `/callback` frontend route, so configure it when creating the GitHub App (the default value would be) `http://127.0.0.0:8080/callback`.
+The GitHub App authorization callback must be processed by the `/callback` frontend route, so configure it to your hostname when creating the GitHub App. The default value would be `http://127.0.0.1:8080/callback`.
 
 Please follow the instructions on how to get the GitHub App credentials in the [main configuration guide](configuration.md#authentication-as-a-github-app), and set them in `config.yaml` as follows:
 


### PR DESCRIPTION
The docs suggested to call `make -f Makefile.web web-start` to run separately the frontend and the backend, but it can not be used this way if the assets have not been generated yet because `with_static` go tag is set by default every time.
```shell
$ make -f Makefile.web web-start
LOG_LEVEL=DEBUG go run -tags "with_static" cmd/lookoutd/*.go web
web/static_files.go:13:2: cannot find package "github.com/src-d/lookout/web/assets" in any of:
	/projects/src/github.com/src-d/lookout/vendor/github.com/src-d/lookout/web/assets (vendor tree)
	/usr/local/go/src/github.com/src-d/lookout/web/assets (from $GOROOT)
	/projects/src/github.com/src-d/lookout/web/assets (from $GOPATH)
Makefile.web:67: recipe for target 'web-start' failed
make: *** [web-start] Error 1
```

Now it can be called:
- `WITHOUT_STATIC=true make -f Makefile.web web-start`
- `make -f Makefile.web web-serve`


I also fixed:
- docs,
- `web-serve` make target