### PR TITLE
Logs enhancement

### DIFF
--- a/provider/github/poster.go
+++ b/provider/github/poster.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// ErrGitHubAPI signals an error while making a request to the GitHub API.
-	ErrGitHubAPI = errors.NewKind("github api error")
+	ErrGitHubAPI = errors.NewKind("github api error: %s")
 	// ErrEventNotSupported signals that this provider does not support the
 	// given event for a given operation.
 	ErrEventNotSupported = errors.NewKind("event not supported")
@@ -85,7 +85,7 @@ func (p *Poster) postPR(ctx context.Context, e *lookout.ReviewEvent,
 	cc, resp, err := client.Repositories.CompareCommits(ctx, owner, repo,
 		e.Base.Hash,
 		e.Head.Hash)
-	if err = handleAPIError(resp, err); err != nil {
+	if err = handleAPIError(resp, err, "commits could not be compared"); err != nil {
 		return err
 	}
 
@@ -268,7 +268,7 @@ func (p *Poster) statusPR(ctx context.Context, e *lookout.ReviewEvent, status lo
 
 	_, _, err = client.Repositories.CreateStatus(ctx, owner, repo, e.CommitRevision.Head.Hash, repoStatus)
 	if err != nil {
-		return ErrGitHubAPI.Wrap(err)
+		return ErrGitHubAPI.Wrap(err, "commit status could not be pushed")
 	}
 
 	return nil

--- a/provider/github/review.go
+++ b/provider/github/review.go
@@ -40,7 +40,8 @@ func createReview(
 	requests := splitReviewRequest(req, batchReviewComments)
 	for i, req := range requests {
 		_, resp, err := client.PullRequests.CreateReview(ctx, owner, repo, number, req)
-		if err = handleAPIError(resp, err); err != nil {
+
+		if err = handleAPIError(resp, err, "review could not be pushed"); err != nil {
 			return err
 		}
 
@@ -99,7 +100,7 @@ func getPostedComment(ctx context.Context, client *Client, owner, repo string, n
 	var reviews []*github.PullRequestReview
 	for {
 		rs, resp, err := client.PullRequests.ListReviews(ctx, owner, repo, number, listReviewsOpts)
-		if handleAPIError(resp, err) != nil {
+		if handleAPIError(resp, err, "pull request reviews could not be listed") != nil {
 			return nil, err
 		}
 
@@ -118,7 +119,7 @@ func getPostedComment(ctx context.Context, client *Client, owner, repo string, n
 
 		for {
 			comments, resp, err := client.PullRequests.ListReviewComments(ctx, owner, repo, int64(number), review.GetID(), listCommentsOpts)
-			if handleAPIError(resp, err) != nil {
+			if handleAPIError(resp, err, "review comments could not be listed") != nil {
 				return nil, err
 			}
 

--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -312,7 +312,7 @@ func (w *Watcher) doPRListRequest(ctx context.Context, client *Client, username,
 
 	prs, resp, err := client.PullRequests.List(ctx, username, repository, &github.PullRequestListOptions{})
 	if err != nil {
-		return resp, nil, ErrGitHubAPI.Wrap(err)
+		return resp, nil, ErrGitHubAPI.Wrap(err, "pull requests could not be listed")
 	}
 
 	if isStatusNotModified(resp.Response) {
@@ -333,7 +333,7 @@ func (w *Watcher) doEventRequest(ctx context.Context, client *Client, username, 
 	)
 
 	if err != nil {
-		return resp, nil, ErrGitHubAPI.Wrap(err)
+		return resp, nil, ErrGitHubAPI.Wrap(err, "repository events could not be listed")
 	}
 
 	if isStatusNotModified(resp.Response) {


### PR DESCRIPTION
fix #487

### before:
```shell
ERROR event processing failed
app=lookout
event-id=b44c158d09bebb40b85ce23763dd9ab179926019
event-type=*pb.ReviewEvent
github.pr=63
head=refs/pull/63/head
repo=https://github.com/dpordomingo/testing-repo.git
error=posting analysis failed: %!s(PANIC=runtime error: invalid memory address or nil pointer 
```
**problems:**
- no info about what caused the error
- error message is a `PANIC` without trace

### after
```shell
ERROR event processing failed

.... (same data as before changes)

error=posting analysis failed: github api error: review could not be pushed:
    POST https://api.github.com/repos/dpordomingo/testing-repo/pulls/63/reviews
    422 Unprocessable Entity
    [{Resource:Review
      Message:Path is invalid
    }]
```
**benefits:**
- error message contains where was caused the problem
  - GitHub API endpoint
  - GitHub API real error message 

these :point_up: new details would have been really useful when debugging https://github.com/src-d/lookout/issues/486

**cons:**
- the workaround done inside [`handleAPIError`](https://github.com/src-d/lookout/pull/488/files#diff-15bfbf8e99100aba04e081d16e13036bR419) could be done directly in `google/go-github` project, but it should be considered separately, so I'd handle it in [a google/go-github PR](https://github.com/dpordomingo/go-github/pull/1/files#diff-9bd6c2575adb220521a096df92e2d502R659)