### PR TITLE
Enhance comment footer on PR messages

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -27,7 +27,7 @@ providers:
     app_id: 17877
     private_key: /local/lookout/private-key.pem
     secretName: lookout-staging-github-key
-    comment_footer: '_If you have feedback about this comment, please, [tell us](%s)._'
+    comment_footer: "_{{if .Feedback}}If you have feedback about this comment made by the analyzer {{.Name}}, please, [tell us]({{.Feedback}}){{else}}Comment made by the analyzer {{.Name}}{{end}}._"
     installation_sync_interval: 5m
 
 analyzers:

--- a/cmd/lookoutd/common.go
+++ b/cmd/lookoutd/common.go
@@ -324,7 +324,7 @@ func (c *queueConsumerCommand) initPoster(conf Config) (lookout.Poster, error) {
 
 	switch c.Provider {
 	case github.Provider:
-		return github.NewPoster(c.pool, conf.Providers.Github), nil
+		return github.NewPoster(c.pool, conf.Providers.Github)
 	case json.Provider:
 		return json.NewPoster(os.Stdout), nil
 	default:

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -8,7 +8,7 @@ analyzers:
 
 providers:
   github:
-    comment_footer: '_If you have feedback about this comment, please, [tell us](%s)._'
+    comment_footer: "_{{if .Feedback}}If you have feedback about this comment made by the analyzer {{.Name}}, please, [tell us]({{.Feedback}}){{else}}Comment made by the analyzer {{.Name}}{{end}}._"
     # The minimum watch interval to discover new pull requests and push events
     watch_min_interval: 2s
     # Authorization with GitHub App

--- a/provider/github/review_test.go
+++ b/provider/github/review_test.go
@@ -225,3 +225,12 @@ func TestConvertCommentsWrongFile(t *testing.T) {
 		Body:     strptr("Line comment"),
 	}}, ghComments)
 }
+
+func TestCouldNotExecuteFooterTemplate(t *testing.T) {
+	require := require.New(t)
+
+	unkonwnDataTemplate, err := newFooterTemplate("Old template {{.UnknownData}}")
+	require.Nil(err)
+	commentsWrongTemplate := addFootnote(context.TODO(), "comments", unkonwnDataTemplate, nil)
+	require.Equal("comments", commentsWrongTemplate)
+}


### PR DESCRIPTION
fix #472 
depends on #510

If the template uses old `sprintf` format (with `%s`), `lookoutd` will log a Warning:
```
WARN invalid footer template: old footer template with '%s' placeholder is no longer supported:
'_If you have %s feedback about this comment made by the analyzer {{.Name}}, please, [tell us]({{.Feedback}})._'
app=lookoutd
```
and no footer will be added; same behavior in other cases like: wrong template, no enough data passed to the template...

ussage, from docs in this PR:

### Add a Custom Message to the Posted Comments

You can configure **source{d} Lookout** to add a custom message to every comment that each analyzer returns. This custom message will be created passing to the template defined by `providers.github.comment_footer`, the `name` and `feedback` defined for each analyzer configuration.

If the template (`providers.github.comment_footer`) is empty, or the analyzer configuration does not define any of the values that the template requires, the custom message won't be added.

Example:
```yaml
providers:
  github:
    comment_footer: "Comment made by analyzer {{.Name}}, [report]({{.Feedback}})."
```

Will require that each analyzer defines its `name` and `feedback` in order to render its custom message appended to its comments, so:

```yaml
analyzers:
  - name: Fancy Analyzer
    addr: ipv4://localhost:9930
    feedback: http://example.com/report-issue
  - name: Awesome Analyzer
    addr: ipv4://localhost:9931
```

Comments from `Fancy Analyzer` will be appended with the message:
>_Comment made by analyzer Fancy Analyzer, [report](http://example.com/report-issue)._

but comments from `Awesome Analyzer` wont be appended with a custom message because its configuration lacks of a key defining its `feedback` value.