### PR TITLE
Update docker-compose command

### DIFF
--- a/docs/lookout-sdk.md
+++ b/docs/lookout-sdk.md
@@ -22,7 +22,7 @@ If your analyzer makes use of UAST, you will also need a [Babelfish server](http
 To start it using [Docker Compose](https://docs.docker.com/compose/) clone this repository, or download [`docker-compose.yml`](../docker-compose.yml), and run:
 
 ```shell
-$ docker-compose up bblfshd
+$ docker-compose up bblfsh
 ```
 
 This will create the [bblfshd](https://github.com/bblfsh/bblfshd) container listening on `localhost:9432`.


### PR DESCRIPTION
This typo was discovered during my interview with @meyskens and @bzz earlier today. The command `docker-compose up bblfshd` does not match the corresponding service in the `docker-compose.yml` so it will error. 