### PR TITLE
Remove unnecessary named import

### DIFF
--- a/store/models/kallax.go
+++ b/store/models/kallax.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	kallax "gopkg.in/src-d/go-kallax.v1"
+	"gopkg.in/src-d/go-kallax.v1"
 	"gopkg.in/src-d/go-kallax.v1/types"
 	"gopkg.in/src-d/lookout-sdk.v0/pb"
 )


### PR DESCRIPTION
caused by https://github.com/golang/go/issues/29556

Otherwise, Travis fails.
https://travis-ci.org/src-d/lookout/builds/490419439#L834

I was introduced by an old version of `golang.org/x/tools`, that must be locally updated in order to generate proper kallax code.

More details at breaking commit https://github.com/golang/tools/commit/cb89afadce946e09f295886d955e7135642e195c
