### PR TITLE
Ensures clean cache on start-up

### DIFF
--- a/provider/github/watcher.go
+++ b/provider/github/watcher.go
@@ -195,7 +195,11 @@ func (w *Watcher) processRepoPRs(
 		return c.watchMinInterval, nil
 	}
 
-	if err != nil && !NoErrNotModified.Is(err) {
+	if NoErrNotModified.Is(err) {
+		return c.watchMinInterval, nil
+	}
+
+	if err != nil {
 		return c.watchMinInterval, err
 	}
 
@@ -226,7 +230,11 @@ func (w *Watcher) processRepoEvents(
 		return c.PollInterval(eventsCategory), nil
 	}
 
-	if err != nil && !NoErrNotModified.Is(err) {
+	if NoErrNotModified.Is(err) {
+		return c.PollInterval(eventsCategory), nil
+	}
+
+	if err != nil {
 		return c.PollInterval(eventsCategory), err
 	}
 


### PR DESCRIPTION
Closes #485. 

Actually I think that the cleanest solution should be to add a `DeleteAll` method [here](https://github.com/gregjones/httpcache/blob/master/diskcache/diskcache.go#L36) that calls the underlying `EraseAll` [here](https://github.com/peterbourgon/diskv/blob/master/diskv.go#L519). But the repository doesn't seem to be very active.