### PR TITLE
Update javascript driver in staging

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -49,9 +49,11 @@ bblfshd-sidecar:
     tag: v2.12.0
   drivers:
     languages:
+      # for js we have to lock old version due to style-analyzer
       javascript:
         repository: bblfsh/javascript-driver
         tag: v2.7.1
+      # for the rest we can use latest
       python:
         repository: bblfsh/python-driver
         tag: v2.8.2

--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -49,11 +49,9 @@ bblfshd-sidecar:
     tag: v2.12.0
   drivers:
     languages:
-      # for js we have to lock old version due to style-analyzer
       javascript:
         repository: bblfsh/javascript-driver
-        tag: v1.2.0
-      # for the rest we can use latest
+        tag: v2.7.1
       python:
         repository: bblfsh/python-driver
         tag: v2.8.2


### PR DESCRIPTION
The style analyzer now supports JS driver version v2.7.1.
This updates the deployment to undo the pinning of the old version.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>