### PR TITLE
Use current json.Poster in sdk, which uses stdout

### DIFF
--- a/cmd/lookout-sdk/push.go
+++ b/cmd/lookout-sdk/push.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/provider/json"
 	"github.com/src-d/lookout/server"
+
+	"gopkg.in/src-d/lookout-sdk.v0/pb"
 
 	uuid "github.com/satori/go.uuid"
 	gocli "gopkg.in/src-d/go-cli.v0"
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	log "gopkg.in/src-d/go-log.v1"
-	"gopkg.in/src-d/lookout-sdk.v0/pb"
 )
 
 func init() {
@@ -59,7 +61,7 @@ func (c *PushCommand) Execute(args []string) error {
 	}
 
 	srv := server.NewServer(server.Options{
-		Poster:     &server.LogPoster{Log: log.DefaultLogger},
+		Poster:     json.NewPoster(os.Stdout),
 		FileGetter: dataHandler.FileGetter,
 		Analyzers: map[string]lookout.Analyzer{
 			"test-analyzer": lookout.Analyzer{Client: client},

--- a/cmd/lookout-sdk/review.go
+++ b/cmd/lookout-sdk/review.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/src-d/lookout"
+	"github.com/src-d/lookout/provider/json"
 	"github.com/src-d/lookout/server"
+
+	"gopkg.in/src-d/lookout-sdk.v0/pb"
 
 	uuid "github.com/satori/go.uuid"
 	gocli "gopkg.in/src-d/go-cli.v0"
-	log "gopkg.in/src-d/go-log.v1"
-	"gopkg.in/src-d/lookout-sdk.v0/pb"
 )
 
 func init() {
@@ -55,7 +57,7 @@ func (c *ReviewCommand) Execute(args []string) error {
 	}
 
 	srv := server.NewServer(server.Options{
-		Poster:     &server.LogPoster{Log: log.DefaultLogger},
+		Poster:     json.NewPoster(os.Stdout),
 		FileGetter: dataHandler.FileGetter,
 		Analyzers: map[string]lookout.Analyzer{
 			"test-analyzer": lookout.Analyzer{Client: client},

--- a/cmd/sdk-test/bblfsh_test.go
+++ b/cmd/sdk-test/bblfsh_test.go
@@ -72,7 +72,7 @@ func (suite *BblfshIntegrationSuite) TestReviewUAST() {
 
 func (suite *BblfshIntegrationSuite) TestReviewLanguage() {
 	r := suite.RunReview()
-	suite.GrepTrue(r, `The file has language detected: "Go"`)
+	suite.GrepTrue(r, `The file has language detected: \"Go\"`)
 }
 
 func (suite *BblfshIntegrationSuite) TestPushNoBblfshError() {
@@ -102,7 +102,7 @@ func (suite *BblfshIntegrationSuite) TestPushUAST() {
 
 func (suite *BblfshIntegrationSuite) TestPushLanguage() {
 	r := suite.RunPush()
-	suite.GrepTrue(r, `The file has language detected: "Go"`)
+	suite.GrepTrue(r, `The file has language detected: \"Go\"`)
 }
 
 func (suite *BblfshIntegrationSuite) TestConnectToDataServer() {


### PR DESCRIPTION
fix #601

`json.Poster` writes the comments in json format into the passed `io.Writter`
so if using `os.Stdout`, comments will be written in `stdout`, and logs in `stderr`

Then comments and logs can be separated:
```bash
$ lookout-sdk review --from HEAD^ --log-format=json 2> log.err
{"analyzer-name":"","file":"cmd/lookout-sdk/push.go","text":"The file has increased in 2 lines."}
{"analyzer-name":"","file":"cmd/lookout-sdk/push.go","line":27,"text":"This line exceeded 120 chars."}
{"analyzer-name":"","file":"cmd/lookout-sdk/review.go","text":"The file has increased in 2 lines."}
{"analyzer-name":"","file":"cmd/lookout-sdk/review.go","line":23,"text":"This line exceeded 120 chars."}
{"analyzer-name":"","file":"cmd/sdk-test/bblfsh_test.go","line":146,"text":"This line exceeded 120 chars."}
```

<details>
  <summary>
    Click to see `log.err`, where  `stderr` was redirected:
  </summary>
<pre>
$ cat log.err
{"app":"lookout-sdk","level":"info","msg":"resolving to/from references","time":"2019-04-09T11:13:08.194352331+02:00"}
{"app":"lookout-sdk","level":"info","msg":"starting looking for Analyzer at ipv4://localhost:9930","time":"2019-04-09T11:13:08.196105525+02:00"}
{"app":"lookout-sdk","level":"info","msg":"starting a DataServer at ipv4://localhost:10301","time":"2019-04-09T11:13:08.196239204+02:00"}
{"addr":"localhost:9432","app":"lookout-sdk","level":"info","msg":"connection state changed to 'IDLE'","name":"bblfsh-proxy","time":"2019-04-09T11:13:08.196725494+02:00"}
{"addr":"localhost:9432","app":"lookout-sdk","level":"info","msg":"connection state changed to 'CONNECTING'","name":"bblfsh-proxy","time":"2019-04-09T11:13:08.196821332+02:00"}
{"app":"lookout-sdk","level":"info","msg":"processing pull request","provider":"","time":"2019-04-09T11:13:08.197346984+02:00"}
{"addr":"localhost:9432","app":"lookout-sdk","level":"info","msg":"connection state changed to 'READY'","name":"bblfsh-proxy","time":"2019-04-09T11:13:08.197541946+02:00"}
{"app":"lookout-sdk","config-file":"repository .lookout.yml","level":"warning","msg":"analyzer 'Dummy' required by configuration file isn't enabled on server","provider":"","time":"2019-04-09T11:13:08.200001107+02:00"}
{"app":"lookout-sdk","config-file":"repository .lookout.yml","level":"warning","msg":"analyzer 'gometalint-analyzer' required by configuration file isn't enabled on server","provider":"","time":"2019-04-09T11:13:08.200028102+02:00"}
{"app":"lookout-sdk","level":"info","msg":"New status","provider":"","status":3,"time":"2019-04-09T11:13:08.200052838+02:00"}
{"analyzer":"test-analyzer","app":"lookout-sdk","grpc.method":"NotifyReviewEvent","grpc.service":"pb.Analyzer","level":"info","msg":"gRPC unary client call started","provider":"","span.kind":"client","system":"grpc","time":"2019-04-09T11:13:08.200125721+02:00"}
{"analyzer":"test-analyzer","app":"lookout-sdk","grpc.method":"GetChanges","grpc.service":"pb.Data","level":"info","msg":"gRPC streaming server call started","provider":"","span.kind":"server","system":"grpc","time":"2019-04-09T11:13:14.772033431+02:00"}
{"analyzer":"test-analyzer","app":"lookout-sdk","duration":119246660,"grpc.code":0,"grpc.method":"GetChanges","grpc.service":"pb.Data","grpc.start_time":"2019-04-09T11:13:14+02:00","level":"info","msg":"gRPC streaming server call finished","provider":"","span.kind":"server","system":"grpc","time":"2019-04-09T11:13:14.891535334+02:00"}
{"analyzer":"test-analyzer","app":"lookout-sdk","duration":6692246859,"grpc.code":0,"grpc.method":"NotifyReviewEvent","grpc.service":"pb.Analyzer","grpc.start_time":"2019-04-09T11:13:08+02:00","level":"info","msg":"gRPC unary client call finished","provider":"","span.kind":"client","system":"grpc","time":"2019-04-09T11:13:14.892412722+02:00"}
{"app":"lookout-sdk","comments":5,"level":"info","msg":"posting analysis","provider":"","time":"2019-04-09T11:13:14.892496472+02:00"}
{"app":"lookout-sdk","level":"info","msg":"New status","provider":"","status":4,"time":"2019-04-09T11:13:14.892988574+02:00"}
</pre>
</details>

And it also works if the logs are requested to be human readable:
```bash
$ lookout-sdk review --from HEAD^ 2> log.err
{"analyzer-name":"","file":"cmd/lookout-sdk/push.go","text":"The file has increased in 2 lines."}
{"analyzer-name":"","file":"cmd/lookout-sdk/push.go","line":27,"text":"This line exceeded 120 chars."}
{"analyzer-name":"","file":"cmd/lookout-sdk/review.go","text":"The file has increased in 2 lines."}
{"analyzer-name":"","file":"cmd/lookout-sdk/review.go","line":23,"text":"This line exceeded 120 chars."}
{"analyzer-name":"","file":"cmd/sdk-test/bblfsh_test.go","line":146,"text":"This line exceeded 120 chars."}
```
<details>
  <summary>
    Click to see `log.err`, where  `stderr` was redirected:
  </summary>
<pre>
$ cat log.err
time="2019-04-09T11:20:29.943666171+02:00" level=info msg="resolving to/from references" app=lookout-sdk
time="2019-04-09T11:20:29.945240973+02:00" level=info msg="starting looking for Analyzer at ipv4://localhost:9930" app=lookout-sdk
time="2019-04-09T11:20:29.945317668+02:00" level=info msg="starting a DataServer at ipv4://localhost:10301" app=lookout-sdk
time="2019-04-09T11:20:29.945477562+02:00" level=info msg="connection state changed to 'IDLE'" addr="localhost:9432" app=lookout-sdk name=bblfsh-proxy
time="2019-04-09T11:20:29.94553613+02:00" level=info msg="connection state changed to 'CONNECTING'" addr="localhost:9432" app=lookout-sdk name=bblfsh-proxy
time="2019-04-09T11:20:29.945905718+02:00" level=info msg="connection state changed to 'READY'" addr="localhost:9432" app=lookout-sdk name=bblfsh-proxy
time="2019-04-09T11:20:29.945935143+02:00" level=info msg="processing pull request" app=lookout-sdk provider=
time="2019-04-09T11:20:29.946451612+02:00" level=warning msg="analyzer 'Dummy' required by configuration file isn't enabled on server" app=lookout-sdk config-file="repository .lookout.yml" provider=
time="2019-04-09T11:20:29.946471481+02:00" level=warning msg="analyzer 'gometalint-analyzer' required by configuration file isn't enabled on server" app=lookout-sdk config-file="repository .lookout.yml" provider=
time="2019-04-09T11:20:29.946493983+02:00" level=info msg="New status" app=lookout-sdk provider= status=pending
time="2019-04-09T11:20:29.946559007+02:00" level=info msg="gRPC unary client call started" analyzer=test-analyzer app=lookout-sdk grpc.method=NotifyReviewEvent grpc.service=pb.Analyzer provider= span.kind=client system=grpc
time="2019-04-09T11:20:30.712726763+02:00" level=info msg="gRPC streaming server call started" analyzer=test-analyzer app=lookout-sdk grpc.method=GetChanges grpc.service=pb.Data provider= span.kind=server system=grpc
time="2019-04-09T11:20:30.77662199+02:00" level=info msg="gRPC streaming server call finished" analyzer=test-analyzer app=lookout-sdk duration=63.882508ms grpc.code=OK grpc.method=GetChanges grpc.service=pb.Data grpc.start_time="2019-04-09T11:20:30+02:00" provider= span.kind=server system=grpc
time="2019-04-09T11:20:30.778021699+02:00" level=info msg="gRPC unary client call finished" analyzer=test-analyzer app=lookout-sdk duration=831.395964ms grpc.code=OK grpc.method=NotifyReviewEvent grpc.service=pb.Analyzer grpc.start_time="2019-04-09T11:20:29+02:00" provider= span.kind=client system=grpc
time="2019-04-09T11:20:30.778126638+02:00" level=info msg="posting analysis" app=lookout-sdk comments=5 provider=
time="2019-04-09T11:20:30.778329528+02:00" level=info msg="New status" app=lookout-sdk provider= status=success
</pre>
</details>