### PR TITLE
Avoid running Makefile.main ::build ::tests on web

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
     - name: 'Web Tests'
       stage: tests
       script:
-        - make dependencies
+        - make -f Makefile.web dependencies
         - make -f Makefile.web build
         - make -f Makefile.web test
         - make -f Makefile.web lint

--- a/Makefile.web
+++ b/Makefile.web
@@ -2,8 +2,13 @@
 
 -include Makefile
 
-# Makefile.main::test -> this::test
+# The @echo replaces the commands defined by `Makefile.main::dependencies`
+dependencies:
+	@echo
+
+# The @echo replaces the commands defined by `Makefile.main::test`
 test: web-test
+	@echo
 
 # this::build -> Makefile.main::build -> Makefile.main::$(COMMANDS)
 # The @echo forces this prerequisites to be run before `Makefile.main::build` ones.


### PR DESCRIPTION
blocks https://github.com/src-d/lookout/pull/626

The purpose of `Makefile.web` is to test and build Lookout web, but it was also testing the whole Lookout because `Makefile.web` includes `Makefile`, and that one includes `src-d/ci/Makefile.main`

This commit overrides `Makefile.main::test` and `Makefile.main::dependencies` targets to avoid calling them.
- `make -f Makefile.web test` will test only the web
- `make -f Makefile.web dependencies` will still install `$(DEPENDENCIES)`, but it won't `go get` all `lookoutd` dependencies, because they're already handled by `make godep`

examples of wrong behavior:
- `Makefile.web::test` calling `Makefile.main::test` &rarr; [travis/job/192547646#L1052](https://travis-ci.com/src-d/lookout/jobs/192547646#L1052)
- `Makefile.web::dependencies` calling `Makefile.main::dependencies` &rarr; [travis/job/192547646#L752](https://travis-ci.com/src-d/lookout/jobs/192547646#L752)

### Why is this needed?
- Because otherwise, failures in `lookoutd` can cause  `Web Tests` Travis stage to fail, what is incorrect.
- This should also speed up the `Web Tests` Travis stage to be ~1'3mins less than before.