### PR TITLE
Add analyer-name to lookout-sdk comments

### DIFF
--- a/cmd/lookout-sdk/push.go
+++ b/cmd/lookout-sdk/push.go
@@ -55,7 +55,7 @@ func (c *PushCommand) Execute(args []string) error {
 		stopCh <- startDataServer()
 	}()
 
-	client, err := c.analyzerClient()
+	analyzer, err := c.analyzer()
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (c *PushCommand) Execute(args []string) error {
 		Poster:     json.NewPoster(os.Stdout),
 		FileGetter: dataHandler.FileGetter,
 		Analyzers: map[string]lookout.Analyzer{
-			"test-analyzer": lookout.Analyzer{Client: client},
+			analyzer.Config.Name: analyzer,
 		},
 		ExitOnError: true,
 	})

--- a/cmd/lookout-sdk/review.go
+++ b/cmd/lookout-sdk/review.go
@@ -51,7 +51,7 @@ func (c *ReviewCommand) Execute(args []string) error {
 		stopCh <- startDataServer()
 	}()
 
-	client, err := c.analyzerClient()
+	analyzer, err := c.analyzer()
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (c *ReviewCommand) Execute(args []string) error {
 		Poster:     json.NewPoster(os.Stdout),
 		FileGetter: dataHandler.FileGetter,
 		Analyzers: map[string]lookout.Analyzer{
-			"test-analyzer": lookout.Analyzer{Client: client},
+			analyzer.Config.Name: analyzer,
 		},
 		ExitOnError: true,
 	})


### PR DESCRIPTION
From the conversation in #624.

The comments contained an empty `analzyer-name` field:
```
$ lookout-sdk review --from HEAD^ --log-format=json 2> log.err
{"analyzer-name":"","file":"cmd/lookout-sdk/push.go","text":"The file has increased in 2 lines."}
```

In `lookoutd` the name is taken from the config file. With this PR `lookout-sdk` fills the info that would be extracted from that `lookout.yml` config file.
```
$ lookout-sdk review --log-level=error
{"analyzer-name":"test-analyzer","file":"cmd/lookout-sdk/event.go","text":"The file has increased in 8 lines."}
{"analyzer-name":"test-analyzer","file":"cmd/lookout-sdk/event.go","line":29,"text":"This line exceeded 120 chars."}
```